### PR TITLE
message: fallback to plain mode if bad markdown is reported

### DIFF
--- a/telegrambot/99-telegrambot.js
+++ b/telegrambot/99-telegrambot.js
@@ -467,6 +467,21 @@ module.exports = function (RED) {
                                             msg.payload.sentMessageId = sent.message_id;
                                             node.send(msg);
                                         }).catch(function (err) {
+                                            // markdown error? try plain mode
+                                            if (
+                                                String(err).includes("can't parse entities in message text:") &&
+                                                msg.payload.options && msg.payload.options.parse_mode === 'Markdown'
+                                            ) {
+                                                delete msg.payload.options.parse_mode;
+                                                node.telegramBot.sendMessage(chatId, messageToSend, msg.payload.options).then(function (sent) {
+                                                    msg.payload.sentMessageId = sent.message_id;
+                                                    node.send(msg);
+                                                }).catch(function (err) {
+                                                    msg.error = err;
+                                                    node.send(msg);
+                                                });
+                                                return;
+                                            }
                                             msg.error = err;
                                             node.send(msg);
                                         });


### PR DESCRIPTION
I'm facing the problem while sending text with `"parse_mode": "Markdown"` option when markdown is not complete or broken.
Proposed is a concept to fallback to send text in plain mode if markdown error reported.

The better fix would be IMO to forcibly delete `parse_mode` unless the text matches some markdown regexp (do you know such?).

Also, the problem may freely arise when pretty valid markdown message splits in 4000-octet chunks.
