### PR TITLE
External ssl termination

### DIFF
--- a/telegrambot/99-telegrambot.html
+++ b/telegrambot/99-telegrambot.html
@@ -32,7 +32,7 @@
             privatekey: { value: "", required: false },
             certificate: { value: "", required: false },
             useselfsignedcertificate: { value: false, required: false },
-            
+            sslterminated: { value: false, required: false },
             verboselogging: { value: false, required: false }
         },
         credentials: {
@@ -58,6 +58,20 @@
             };
             updateOptions();
             $("#node-config-input-updatemode").change(updateOptions);
+
+            // sslTerminated on / off
+            var sslTerminated = function() {
+                var mode = $('#node-config-input-sslterminated').prop('checked');
+                if (mode === false) {
+                    $('#node-config-input-privatekey').parent().show();
+                    $('#node-config-input-certificate').parent().show();
+                } else {
+                    $('#node-config-input-privatekey').parent().hide();
+                    $('#node-config-input-certificate').parent().hide();
+                }
+            };
+            sslTerminated();
+            $('#node-config-input-sslterminated').change(sslTerminated);
 
             // socks5 on / off
             var useSocks5 = function() {
@@ -152,8 +166,12 @@
                     <label for="node-config-input-useselfsignedcertificate"><i class="fa fa-pencil"></i> Certificate is self-signed</label>
                     <input type="checkbox" id="node-config-input-useselfsignedcertificate" style="display: inline-block; width: auto; vertical-align: top;">
                 </div>
+                <div class="form-row">
+                    <label for="node-config-input-sslterminated"><i class="fa fa-pencil"></i> SSL terminated by reverse proxy</label>
+                    <input type="checkbox" id="node-config-input-sslterminated" style="display: inline-block; width: auto; vertical-align: top;">
+                </div>
 
-                <div class="form-tips" style="width: auto"><b>Tip:</b> Webhook mode requires a HTTPS certificate. The certificate can also be a self-signed (=custom) one. If any of the host, key, certificate properties is left blank the bot will default to polling mode.</div>
+                <div class="form-tips" style="width: auto"><b>Tip:</b> Webhook mode requires a HTTPS certificate. The certificate can also be a self-signed (=custom) one. If any of the host, key, certificate properties is left blank the bot will default to polling mode. If SSL termination is alredy handled by reverse proxy, key and certificate is not required.</div>
             </div>
         </div>
 

--- a/telegrambot/99-telegrambot.js
+++ b/telegrambot/99-telegrambot.js
@@ -111,10 +111,10 @@ module.exports = function (RED) {
                                     autoOpen: true,
                                     port : this.localBotPort,
                                 };
-								if (!this.sslTerminated) {
-									webHook.key = this.privateKey;
+                                if (!this.sslTerminated) {
+                                    webHook.key = this.privateKey;
                                     webHook.cert = this.certificate;
-								}
+                                }
                                 var options =
                                 {
                                     webHook: webHook,

--- a/telegrambot/99-telegrambot.js
+++ b/telegrambot/99-telegrambot.js
@@ -71,7 +71,8 @@ module.exports = function (RED) {
         this.privateKey = n.privatekey;
         this.certificate = n.certificate;
         this.useSelfSignedCertificate = n.useselfsignedcertificate;
-    
+        this.sslTerminated = n.sslterminated;
+
         // 4. optional when request via SOCKS5 is used. 
         this.useSocks = n.usesocks;
         if(this.useSocks){
@@ -88,7 +89,7 @@ module.exports = function (RED) {
         
         this.useWebhook = false;
         if (this.updateMode == "webhook") {
-            if (this.botHost && this.privateKey && this.certificate) {
+            if (this.botHost && (this.sslTerminated || (this.privateKey && this.certificate))) {
                 this.useWebhook = true;
             } else{
                 self.error("Configuration data for webhook is not complete. Defaulting to polling mode.");
@@ -109,9 +110,11 @@ module.exports = function (RED) {
                                 {
                                     autoOpen: true,
                                     port : this.localBotPort,
-                                    key: this.privateKey,
-                                    cert: this.certificate,
-                                }
+                                };
+								if (!this.sslTerminated) {
+									webHook.key = this.privateKey;
+                                    webHook.cert = this.certificate;
+								}
                                 var options =
                                 {
                                     webHook: webHook,
@@ -136,7 +139,7 @@ module.exports = function (RED) {
 
                                 var botUrl = "https://" + this.botHost + ":" + this.publicBotPort + "/" + this.token; 
                                 var setWebHookOptions;
-                                if (this.useSelfSignedCertificate){
+                                if (!this.sslTerminated && this.useSelfSignedCertificate){
                                     setWebHookOptions = {
                                         certificate: options.webHook.cert,
                                     };


### PR DESCRIPTION
I've gone ahead and added a `sslterminated` option along with its UI. This allow the Telegram bot node to start a bare HTTP server, without the need to handle SSL-related stuff. It is suitable for some localtunnel-style architecture like this:

![image](https://user-images.githubusercontent.com/1465267/71308779-9fbf3480-243b-11ea-903b-aa088f1ee8a7.png)

This way the SSL termination happens only on the cloud server, and could be easily integrated with Let's Encrypt.

This fixes #92 .