### PR TITLE
added new command filter option in telegram reciever node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+ - New option in `Telegram reciever node` to automatically filter configured `command nodes`
+ - New `CHANGELOG` file to remove the info from the `README` - [#107](https://github.com/windkh/node-red-contrib-telegrambot/pull/107)
+
 ### Changed
  - New updated icons to - [#106](https://github.com/windkh/node-red-contrib-telegrambot/issues/106)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Telegram bot nodes for node-red
-[![platform](https://img.shields.io/badge/platform-Node--RED-red)](https://nodered.org)
+[![Platform](https://img.shields.io/badge/platform-Node--RED-red)](https://nodered.org)
 ![License](https://img.shields.io/github/license/windkh/node-red-contrib-telegrambot.svg)
 ![Release](https://img.shields.io/npm/v/node-red-contrib-telegrambot.svg)
 ![NPM](https://img.shields.io/npm/dm/node-red-contrib-telegrambot.svg)

--- a/telegrambot/99-telegrambot.html
+++ b/telegrambot/99-telegrambot.html
@@ -255,7 +255,8 @@
         defaults: {
             name: { value: "" },
             bot: { value:"", type: "telegram bot", required: true },
-            saveDataDir: { value: "" }
+            saveDataDir: { value: "" },
+            filterCommands: { value: false },
         },
         inputs: 0,
         outputs: 2,
@@ -278,6 +279,10 @@
     <div class="form-row">
         <label for="node-input-saveDataDir"><i class="fa fa-hdd-o"></i> Download Directory</label>
         <input type="text" id="node-input-saveDataDir" placeholder="Download directory">
+    </div>
+    <div class="form-row">
+        <label for="node-input-filterCommands"><i class="fa fa-filter"></i> Filter</label>
+        <input type="checkbox" id="node-input-filterCommands" style="display: inline-block; width: auto; vertical-align: top;"> commands (from configured command nodes)
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
@@ -304,6 +309,7 @@
     <p>Other properties may be present depending on the type of message.</p>
     <code>msg.originalMessage</code> contains the raw data object from the underlying library,
     and contains many useful properties.</p>
+    <p>Note: If you are using other <code>command nodes</code>, you can set this node to filter those commands so that the message only appears in the configured command node and not in this node</p>
 </script>
 
 


### PR DESCRIPTION
I've added a way to automatically filter all command messages in the `Telegram receiver node` from configured command nodes only. With this filter activated you will not receive any command message if there are other active configured command nodes.

I've set this as a filter, so no big changes for older versions. The filter is in the configuration of `Telegram reciever node`.

I've updated the `CHANGELOG`, I don't know if `v8.0.0` already has the new icons updated, so I left the new changes under the `Unreleased` section.

Check it out! What do you think?