### PR TITLE
Fix payload content documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you want to support this free project. Any help is welcome. You can donate by
  - skrashevich: for providing approveChatJoinRequest, declineChatJoinRequest
  - ShotokanZH: for providing the web app data example
  - Dodoooh: for providing the send to topic example flow
+ - MariusSchiffer: for improving documentation
 
  
 
@@ -363,6 +364,7 @@ The node has up to two outputs (selectable via the *Send errors to second output
 Additionally to sending content, the sender node can be used to issue commands direct to the API. In this case the `msg.payload` elements contain (see examples for further details):
 - `msg.payload.type` - one of the commands listed below
 - `msg.payload.content` - required command arguments
+- `msg.payload.chatId` - chatId if required
 - `msg.payload.options` (optional) - additional command arguments
 
 
@@ -386,39 +388,39 @@ The `msg.payload.type` needs to be set to one of the following values:
 | **leaveChat** | - | - | https://core.telegram.org/bots/api#leavechat |
 | **exportChatInviteLink** | - | - | https://core.telegram.org/bots/api#exportchatinvitelink |
 | **createChatInviteLink** | - | - | https://core.telegram.org/bots/api#createchatinvitelink |
-| **banChatMember** | { chat_id (integer/string), user_id (integer) } | optional arguments | https://core.telegram.org/bots/api#banchatmember |
-| **unbanChatMember** | { chat_id (integer/string), user_id (integer) } | optional arguments | https://core.telegram.org/bots/api#unbanchatmember |
-| **restrictChatMember** | { chat_id (integer/string), user_id (integer), permissions (ChatPermissions) } | optional arguments | https://core.telegram.org/bots/api#restrictchatmember |
-| **promoteChatMember** | { chat_id (integer/string), user_id (integer) } | optional arguments | https://core.telegram.org/bots/api#promotechatmember |
+| **banChatMember** | user_id (integer)  | optional arguments | https://core.telegram.org/bots/api#banchatmember |
+| **unbanChatMember** | user_id (integer)  | optional arguments | https://core.telegram.org/bots/api#unbanchatmember |
+| **restrictChatMember** | user_id (integer) | { permissions (ChatPermissions) } | https://core.telegram.org/bots/api#restrictchatmember |
+| **promoteChatMember** | user_id (integer)  | optional arguments | https://core.telegram.org/bots/api#promotechatmember |
 | **setChatPhoto** | photo (InputFile) | - | https://core.telegram.org/bots/api#setchatphoto |
 | **setChatTitle** | title (string) | - | https://core.telegram.org/bots/api#setchattitle |
 | **setChatDescription** | optional arguments | optional arguments | https://core.telegram.org/bots/api#setchatdescription |
-| **pinChatMessage** | { chat_id (integer/string), message_id (integer) | optional arguments | https://core.telegram.org/bots/api#pinchatmessage |
+| **pinChatMessage** | message_id (integer)  | optional arguments | https://core.telegram.org/bots/api#pinchatmessage |
 | **unpinChatMessage** | optional arguments | - | https://core.telegram.org/bots/api#unpinchatmessage |
 | **unpinAllChatMessages** | - | - | https://core.telegram.org/bots/api#unpinallchatmessages |
 | **getChatAdministrators** | - | - | https://core.telegram.org/bots/api#getchatadministrators |
 | **getChatMemberCount** | - | - | https://core.telegram.org/bots/api#getchatmembercount |
 | **getChat** | - | - | https://core.telegram.org/bots/api#getchat |
-| **getChatMember** | { chat_id (integer/string), user_id (integer) } | - | https://core.telegram.org/bots/api#getchatmember |
-| **approveChatJoinRequest** | { chat_id (integer/string), user_id (integer) } | - | https://core.telegram.org/bots/api#approvechatjoinrequest |
-| **declineChatJoinRequest** | { chat_id (integer/string), user_id (integer) } | - | https://core.telegram.org/bots/api#declinechatjoinrequest |
+| **getChatMember** | user_id (integer) | - | https://core.telegram.org/bots/api#getchatmember |
+| **approveChatJoinRequest** | user_id (integer)  | - | https://core.telegram.org/bots/api#approvechatjoinrequest |
+| **declineChatJoinRequest** | user_id (integer)  | - | https://core.telegram.org/bots/api#declinechatjoinrequest |
 | **sendInvoice** | { title (string), description (string), payload (string), providerToken (string), startParameter (string), currency (string), prices (string) } | optional arguments | https://core.telegram.org/bots/api#sendinvoice |
 | **answerPreCheckoutQuery** | { preCheckoutQueryId (string), ok (boolean)} | optional arguments | https://core.telegram.org/bots/api#answerprecheckoutquery |
 | **pre_checkout_query** | { preCheckoutQueryId (string), ok (boolean)} | optional arguments | https://core.telegram.org/bots/api#answerprecheckoutquery |
 | **shipping_query** | { shippingQueryId (string), ok (boolean) } | optional arguments | https://core.telegram.org/bots/api#answershippingquery |
 | **answerShippingQuery** | { shippingQueryId (string), ok (boolean) } | optional arguments | https://core.telegram.org/bots/api#answershippingquery |
 | **getForumTopicIconStickers** | - | - | https://core.telegram.org/bots/api#getforumtopiciconstickers |
-| **createForumTopic** | { chat_id (integer/string), name (string) } | optional arguments | https://core.telegram.org/bots/api#createforumtopic |
-| **editForumTopic** | { chat_id (integer/string), message_thread_id (integer), name (string) } | optional arguments | https://core.telegram.org/bots/api#editforumtopic |
-| **closeForumTopic** | { chat_id (integer/string), message_thread_id (integer) } | - | https://core.telegram.org/bots/api#closeforumtopic |
-| **reopenForumTopic** | { chat_id (integer/string), message_thread_id (integer) } | - | https://core.telegram.org/bots/api#reopenforumtopic |
-| **deleteForumTopic** | { chat_id (integer/string), message_thread_id (integer) } | - | https://core.telegram.org/bots/api#deleteforumtopic |
-| **editGeneralForumTopic** | { chat_id (integer/string), name (string) } | - | https://core.telegram.org/bots/api#editgeneralforumtopic |
-| **closeGeneralForumTopic** | { chat_id (integer/string) } | - | https://core.telegram.org/bots/api#closegeneralforumtopic |
-| **reopenGeneralForumTopic** | { chat_id (integer/string) } | - | https://core.telegram.org/bots/api#reopengeneralforumtopic |
-| **hideGeneralForumTopic** | { chat_id (integer/string) } | - | https://core.telegram.org/bots/api#hidegeneralforumtopic |
-| **unhideGeneralForumTopic** | { chat_id (integer/string) } | - | https://core.telegram.org/bots/api#unhidegeneralforumtopic |
-| **stopPoll** | { chat_id (integer/string), message_id (integer) } | optional arguments | https://core.telegram.org/bots/api#stoppoll |
+| **createForumTopic** | name (string) | optional arguments | https://core.telegram.org/bots/api#createforumtopic |
+| **editForumTopic** | message_thread_id (integer) | optional arguments | https://core.telegram.org/bots/api#editforumtopic |
+| **closeForumTopic** | message_thread_id (integer) | - | https://core.telegram.org/bots/api#closeforumtopic |
+| **reopenForumTopic** | message_thread_id (integer) | - | https://core.telegram.org/bots/api#reopenforumtopic |
+| **deleteForumTopic** | message_thread_id (integer) | - | https://core.telegram.org/bots/api#deleteforumtopic |
+| **editGeneralForumTopic** | name (string) | - | https://core.telegram.org/bots/api#editgeneralforumtopic |
+| **closeGeneralForumTopic** | - | - | https://core.telegram.org/bots/api#closegeneralforumtopic |
+| **reopenGeneralForumTopic** | - | - | https://core.telegram.org/bots/api#reopengeneralforumtopic |
+| **hideGeneralForumTopic** | - | - | https://core.telegram.org/bots/api#hidegeneralforumtopic |
+| **unhideGeneralForumTopic** | - | - | https://core.telegram.org/bots/api#unhidegeneralforumtopic |
+| **stopPoll** | message_id (integer) | optional arguments | https://core.telegram.org/bots/api#stoppoll |
 
 
 The content format of the command arguments (required and optional) depends on the api command.  


### PR DESCRIPTION
Previously, some API commands were falsely documented as expecting an object in `payload.content`.

I'm still checking over the rest of the commands.