### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/windkh/node-red-contrib-telegrambot/security/code-scanning/3](https://github.com/windkh/node-red-contrib-telegrambot/security/code-scanning/3)

To fix this problem, you should add a top-level `permissions` block in the workflow YAML or, for greater granularity, within each job. Since all jobs only need minimal permissions to read repository contents and publish, you should set the permissions at the root of the workflow, applying them to all jobs unless individually overridden.  
- **File to change:** `.github/workflows/npm-publish.yml`
- **Region to edit:** Immediately after the `name:` block, before the `on:` block (or at the job level if you prefer more granularity).
- **What to add:** Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
  This ensures the default GITHUB_TOKEN is limited to read-only on repository contents. If you later use `GITHUB_TOKEN` for publishing to GPR, add the necessary extra permissions (e.g. `packages: write`) for that job.  
- **Dependencies:** None needed, only a workflow YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
