### PR TITLE
catch unhandle promise rejections

### DIFF
--- a/telegrambot/nodes/bot-node.js
+++ b/telegrambot/nodes/bot-node.js
@@ -55,10 +55,14 @@ module.exports = function (RED) {
             let startTime = new Date().getTime();
 
             let result = super.getUpdates(form);
-            result.then((updates) => {
-                let endTime = new Date().getTime();
-                this.emit('getUpdates_end', this.cycle, endTime - startTime, updates);
-            });
+            result
+                .then((updates) => {
+                    let endTime = new Date().getTime();
+                    this.emit('getUpdates_end', this.cycle, endTime - startTime, updates);
+                })
+                .catch(() => {
+                    // Errors from getUpdates are handled by the caller; suppress unhandled rejection here.
+                });
 
             return result;
         }
@@ -383,21 +387,33 @@ module.exports = function (RED) {
                     certificate: options.webHook.cert,
                 };
             }
-            newTelegramBot.setWebHook(botUrl, setWebHookOptions).then(function (success) {
-                if (self.verbose) {
-                    newTelegramBot.getWebHookInfo().then(function (result) {
-                        self.log('Webhook enabled: ' + JSON.stringify(result));
-                    });
-                }
+            newTelegramBot
+                .setWebHook(botUrl, setWebHookOptions)
+                .then(function (success) {
+                    if (self.verbose) {
+                        newTelegramBot
+                            .getWebHookInfo()
+                            .then(function (result) {
+                                self.log('Webhook enabled: ' + JSON.stringify(result));
+                            })
+                            .catch(function (err) {
+                                self.warn('Failed to get webhook info: ' + err);
+                            });
+                    }
 
-                if (success) {
-                    self.status = 'connected'; // TODO: check if this must be SetStatus
-                } else {
-                    self.abortBot('Failed to set webhook ' + botUrl, function () {
+                    if (success) {
+                        self.status = 'connected'; // TODO: check if this must be SetStatus
+                    } else {
+                        self.abortBot('Failed to set webhook ' + botUrl, function () {
+                            self.error('Bot stopped: Webhook not set.');
+                        });
+                    }
+                })
+                .catch(function (err) {
+                    self.abortBot('Failed to set webhook ' + botUrl + ': ' + err, function () {
                         self.error('Bot stopped: Webhook not set.');
                     });
-                }
-            });
+                });
 
             return newTelegramBot;
         };

--- a/telegrambot/nodes/in-node.js
+++ b/telegrambot/nodes/in-node.js
@@ -176,19 +176,29 @@ module.exports = function (RED) {
                     // downloadable "blob" message?
                     if (messageDetails.blob) {
                         let fileId = msg.payload.content;
-                        telegramBot.getFileLink(fileId).then(function (weblink) {
-                            msg.payload.weblink = weblink;
+                        telegramBot
+                            .getFileLink(fileId)
+                            .then(function (weblink) {
+                                msg.payload.weblink = weblink;
 
-                            // download and provide with path
-                            if (config.saveDataDir) {
-                                telegramBot.downloadFile(fileId, config.saveDataDir).then(function (path) {
-                                    msg.payload.path = path;
+                                // download and provide with path
+                                if (config.saveDataDir) {
+                                    telegramBot
+                                        .downloadFile(fileId, config.saveDataDir)
+                                        .then(function (path) {
+                                            msg.payload.path = path;
+                                            node.send([msg, null]);
+                                        })
+                                        .catch(function (err) {
+                                            node.error('Failed to download file: ' + err, msg);
+                                        });
+                                } else {
                                     node.send([msg, null]);
-                                });
-                            } else {
-                                node.send([msg, null]);
-                            }
-                        });
+                                }
+                            })
+                            .catch(function (err) {
+                                node.error('Failed to get file link: ' + err, msg);
+                            });
                         // vanilla message
                     } else if (node.filterCommands && node.config.isCommandRegistered(messageDetails.content)) {
                         // Do nothing


### PR DESCRIPTION
My node-red instance will crash if the network/Internet disappears.  This finds some spots with unhandled promise rejections.

```
4 Apr 00:35:03 - [info] node-red-contrib-telegrambot: WebHook listening on 0.0.0.0:8445
Unhandled rejection RequestError: Error: getaddrinfo EAI_AGAIN api.telegram.org
    at new RequestError (/data/node_modules/request-promise-core/lib/errors.js:14:15)
    at Request.plumbing.callback (/data/node_modules/request-promise-core/lib/plumbing.js:87:29)
    at Request.RP$callback [as _callback] (/data/node_modules/request-promise-core/lib/plumbing.js:46:31)
    at self.callback (/data/node_modules/@cypress/request/request.js:183:22)
    at Request.emit (node:events:524:28)
    at Request.onRequestError (/data/node_modules/@cypress/request/request.js:869:8)
    at ClientRequest.emit (node:events:524:28)
    at emitErrorEvent (node:_http_client:101:11)
    at TLSSocket.socketErrorListener (node:_http_client:504:5)
    at TLSSocket.emit (node:events:524:28)
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
```