### PR TITLE
fix infinite loop/resource exhaustion on disconnect

### DIFF
--- a/telegrambot/nodes/bot-node.js
+++ b/telegrambot/nodes/bot-node.js
@@ -555,8 +555,8 @@ module.exports = function (RED) {
         };
 
         // Activates the bot or returns the already activated bot.
-        this.getTelegramBot = function () {
-            if (!this.telegramBot) {
+        this.getTelegramBot = function (createIfMissing = true) {
+            if (createIfMissing && !this.telegramBot) {
                 if (this.credentials) {
                     this.token = this.getBotToken(this.credentials.token);
                     if (this.token) {

--- a/telegrambot/nodes/command-node.js
+++ b/telegrambot/nodes/command-node.js
@@ -79,7 +79,7 @@ module.exports = function (RED) {
         };
 
         this.stop = function () {
-            let telegramBot = this.config.getTelegramBot();
+            let telegramBot = this.config.getTelegramBot(false);
             if (telegramBot) {
                 telegramBot.off('message');
             }

--- a/telegrambot/nodes/control-node.js
+++ b/telegrambot/nodes/control-node.js
@@ -66,7 +66,7 @@ module.exports = function (RED) {
         };
 
         this.stop = function () {
-            let telegramBot = node.config.getTelegramBot();
+            let telegramBot = node.config.getTelegramBot(false);
             if (telegramBot) {
                 telegramBot.off('getUpdates_start');
                 telegramBot.off('getUpdates_end');

--- a/telegrambot/nodes/event-node.js
+++ b/telegrambot/nodes/event-node.js
@@ -110,7 +110,7 @@ module.exports = function (RED) {
         };
 
         this.stop = function () {
-            let telegramBot = this.config.getTelegramBot();
+            let telegramBot = this.config.getTelegramBot(false);
             if (telegramBot) {
                 telegramBot.off(this.event);
             }

--- a/telegrambot/nodes/in-node.js
+++ b/telegrambot/nodes/in-node.js
@@ -125,7 +125,7 @@ module.exports = function (RED) {
         };
 
         this.stop = function () {
-            let telegramBot = this.config.getTelegramBot();
+            let telegramBot = this.config.getTelegramBot(false);
             if (telegramBot) {
                 telegramBot.off('message');
 


### PR DESCRIPTION
When webhook startup failed with EADDRINUSE, abortBot() clears self.telegramBot.

In the "stopped" status transition, several child nodes will call `config.getTelegramBot()` inside their stop() handlers.  This recreates the bot when missing, so the failed webhook startup immediately retried and retried until an OOM.

Let's change getTelegramBot() to accept an optional createIfMissing flag, defaulting to true to preserve normal behavior. The child nodes that only need to detach listeners during shutdown now call `getTelegramBot(false)`, so they reuse the existing instance if present but don't recreate a bot while the config node is stopping after a webhook bind failure.

This should surface as a single real startup failure instead of endless bot recreation and bringing down my node-red instance :)

Logs:

```
... several thousands of these ...
16 Apr 19:49:04 - [error] [telegram bot:fa4ea851c4b9ba3a] Bot stopped: failed to open web hook.
16 Apr 19:49:04 - [warn] [telegram bot:fa4ea851c4b9ba3a] Opening webhook failed: Error: listen EADDRINUSE: address already in use 0.0.0.0:8445
16 Apr 19:49:04 - [error] [telegram bot:fa4ea851c4b9ba3a] Bot stopped: failed to open web hook.
16 Apr 19:49:04 - [warn] [telegram bot:fa4ea851c4b9ba3a] Opening webhook failed: Error: listen EADDRINUSE: address already in use 0.0.0.0:8445
16 Apr 19:49:04 - [error] [telegram bot:fa4ea851c4b9ba3a] Bot stopped: failed to open web hook.
16 Apr 19:49:04 - [warn] [telegram bot:fa4ea851c4b9ba3a] Opening webhook failed: Error: listen EADDRINUSE: address already in use 0.0.0.0:8445
16 Apr 19:49:04 - [error] [telegram bot:fa4ea851c4b9ba3a] Bot stopped: failed to open web hook.
16 Apr 19:49:04 - [warn] [telegram bot:fa4ea851c4b9ba3a] Opening webhook failed: Error: listen EADDRINUSE: address already in use 0.0.0.0:8445

<--- Last few GCs --->

[7:0x112f7c70] 12236682 ms: Mark-Compact 4016.2 (4137.0) -> 4004.3 (4141.8) MB, 3770.40 / 0.03 ms  (average mu = 0.228, current mu = 0.122) allocation failure; scavenge might not succeed
[7:0x112f7c70] 12242978 ms: Mark-Compact 4020.7 (4141.8) -> 4009.1 (4146.5) MB, 6041.76 / 0.03 ms  (average mu = 0.123, current mu = 0.040) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xb76db1 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node-red]
 2: 0xee62f0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node-red]
 3: 0xee65d7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node-red]
 4: 0x10f82d5  [node-red]
 5: 0x1110158 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node-red]
 6: 0x10e6271 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node-red]
 7: 0x10e7405 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node-red]
 8: 0x10c4a56 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node-red]
 9: 0x1520596 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node-red]
10: 0x7cfc57ed9ef6 
./entrypoint.sh: line 14:     7 Aborted                 (core dumped) /usr/local/bin/node $NODE_OPTIONS node_modules/node-red/red.js --userDir /data $FLOWS "${@}"
16 Apr 19:49:12 - [info] 
```