### PR TITLE
ci(npm-publish): route pre-release tags to the `beta` dist-tag (#448)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,11 @@ jobs:
                   node-version: 12
                   registry-url: https://registry.npmjs.org/
             - run: npm ci
-            - run: npm publish
+            # GitHub releases flagged "pre-release" publish to the `beta`
+            # dist-tag so existing users on Manage Palette (which tracks
+            # `latest`) don't auto-upgrade onto unproven builds. Stable
+            # releases publish to `latest` as before.
+            - run: npm publish ${{ github.event.release.prerelease && '--tag beta' || '' }}
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 


### PR DESCRIPTION
## Summary

One-line YAML change in `.github/workflows/npm-publish.yml`: GitHub releases marked as **pre-release** now publish under npm's `beta` dist-tag instead of `latest`. Stable releases (no pre-release flag) continue to publish to `latest` unchanged.

\`\`\`yaml
- run: npm publish ${{ github.event.release.prerelease && '--tag beta' || '' }}
\`\`\`

## Why

Groundwork for the V18.0.0 migration tracked in #448. The migration is large enough to need a beta channel: existing users on Manage Palette stay on V17.4.13 (\`latest\`), early adopters opt in via \`npm install node-red-contrib-telegrambot@beta\`.

Lands on master ahead of the migration branch so the publish path is verified independently of the substantive work.

## Test plan

- [x] YAML syntax check (manual read; the GitHub Actions expression is documented and standard)
- [ ] First pre-release tag off \`migration/ntba-v1\` confirms the conditional fires (\`V18.0.0-beta.1\` should land under \`beta\`, not \`latest\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)