### PR TITLE
17.4.15: processError advances queue on non-retryable failure (#450 round 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [17.4.15] - 2026-06-16
+### Fix sibling queue-wedge in `out-node.js`'s `processError` non-retryable branch (#450 round 2). WJ4IoT's V17.4.13 retest surfaced a second wedge mechanism that V17.4.14 didn't cover. Trigger: a Markdown-mode message containing an unescaped `_` (or `*`, `[`, etc.) causes Telegram to reject with `ETELEGRAM: 400 Bad Request: can't parse entities`. `processError` matches the non-retry branch (it's not 429 / ENOTFOUND / ECONNRESET), logs `node.error()`, invokes `nodeDone()` — and never calls `queueManager.processNext(chatId)`. Same wedge symptom as V17.4.14's empty-content drop fix: `processing[chatId]` stays `true` forever, subsequent messages on that chat queue but never start. WJ4IoT's manual repro: send a message with `_` in the text, then send a plain-text message — the second one silently never sends until redeploy.
+
+### Fix: add `node.queueManager.processNext(chatId)` after the non-retry branch's logging. The retry branch (429 / ENOTFOUND / ECONNRESET) uses `repeatProcessMessage` which re-runs the same message; a successful retry's `processResult` then advances naturally — so only the give-up path needed the explicit advance.
+
+### 1 new mocha regression case proves the fix end-to-end: a bot stub whose first `sendMessage` rejects with the canonical Markdown-parse-error string, second succeeds. Pre-fix the second send wouldn't reach the bot. Post-fix both calls land and `processing[123]` is `false`. 242 passing.
+
 # [17.4.14] - 2026-06-15
 ### Fix queue-wedge in `out-node.js` when `msg.payload.content` is missing (#450 root fix). The sender's per-chatId QueueManager (introduced in [6c44a22](https://github.com/windkh/node-red-contrib-telegrambot/commit/6c44a22) "fix #300 fix #413" on 2026-03-07) has had a latent bug since: when a message arrives with `msg.payload.type` set but `msg.payload.content` empty, `hasContent(msg)` warns "msg.payload.content is empty" and returns false. The dispatching switch's case branch (`if (this.hasContent(msg)) { ... } break;`) then falls through to `break` without ever calling `processResult` / `processError`, so the QueueManager's `processing[chatId]` flag stays `true` forever. Every subsequent send to that chatId enqueues but never starts, until the bot config is redeployed (which rebuilds the queue from scratch). Reproduces deterministically with a `telegram command` node wired to `telegram sender` where the command path produces a typed-but-empty payload.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "17.4.13",
+    "version": "17.4.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-telegrambot",
-            "version": "17.4.13",
+            "version": "17.4.15",
             "license": "MIT",
             "dependencies": {
                 "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "17.4.14",
+    "version": "17.4.15",
     "description": "Telegram bot nodes for Node-RED",
     "dependencies": {
         "bluebird": "^3.7.2",

--- a/telegrambot/nodes/out-node.js
+++ b/telegrambot/nodes/out-node.js
@@ -156,6 +156,17 @@ module.exports = function (RED) {
                         node.error(errorMessage, msg);
                     }
                 }
+                // The non-retry error branch logs the exception and moves on —
+                // but the queue head must also advance so subsequent messages
+                // on the same chatId can run. Without this, a non-retryable
+                // failure (e.g. `ETELEGRAM: 400 Bad Request: can't parse
+                // entities` when a Markdown-mode message contains an
+                // unescaped `_` / `*` / `[`) wedges the chat's queue
+                // permanently, exactly the way the empty-content drop did
+                // before V17.4.14 (#450 round 2). The retry branch below
+                // calls `repeatProcessMessage` which re-runs the head; only
+                // the give-up path needs explicit advance.
+                node.queueManager.processNext(chatId);
             } else {
                 let errorMessage = retryReason + ': retrying in ' + retryAfter + 's';
                 node.status({

--- a/test/nodes/out-node.test.js
+++ b/test/nodes/out-node.test.js
@@ -322,3 +322,87 @@ describe('telegram sender (out-node) — queue advance on empty-content drop (#4
         });
     });
 });
+
+describe('telegram sender (out-node) — queue advance on non-retry processError (#450 round 2)', function () {
+    before(function (done) {
+        helper.startServer(done);
+    });
+
+    after(function (done) {
+        helper.stopServer(done);
+    });
+
+    afterEach(function () {
+        helper.unload();
+    });
+
+    function flow() {
+        return [
+            { id: 'b1', type: 'telegram bot', botname: 'b', updatemode: 'sendonly' },
+            { id: 's1', type: 'telegram sender', bot: 'b1', wires: [['out']] },
+            { id: 'out', type: 'helper' },
+        ];
+    }
+
+    function makeRejectingThenAcceptingBotStub(record) {
+        const stub = { options: { baseApiUrl: 'https://api.telegram.org' } };
+        let calls = 0;
+        stub.sendMessage = function () {
+            calls++;
+            record.push({ method: 'sendMessage', args: Array.from(arguments) });
+            if (calls === 1) {
+                return Promise.reject(new Error("ETELEGRAM: 400 Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 7"));
+            }
+            return Promise.resolve({ message_id: 999 });
+        };
+        return stub;
+    }
+
+    it('non-retryable error (Markdown parse failure) advances the queue so subsequent messages run', function (done) {
+        helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
+            try {
+                const s = helper.getNode('s1');
+                const cfg = helper.getNode('b1');
+                const record = [];
+                cfg.getTelegramBot = function () {
+                    return makeRejectingThenAcceptingBotStub(record);
+                };
+                s.error = function () {};
+                s.warn = function () {};
+
+                s.receive({
+                    payload: {
+                        chatId: 123,
+                        type: 'message',
+                        content: 'underscore _ inside',
+                        options: { parse_mode: 'Markdown' },
+                    },
+                });
+
+                setTimeout(function () {
+                    s.receive({
+                        payload: {
+                            chatId: 123,
+                            type: 'message',
+                            content: 'plain text, no markdown specials',
+                        },
+                    });
+
+                    setTimeout(function () {
+                        try {
+                            expect(record).to.have.length(2);
+                            expect(record[0].args[1]).to.include('underscore');
+                            expect(record[1].args[1]).to.include('plain text');
+                            expect(s.queueManager.processing.get(123)).to.equal(false);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }, 50);
+                }, 50);
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

V17.4.14 fixed one queue-wedge mechanism in `out-node.js` (the empty-content drop in `hasContent`). WJ4IoT's [retest on #450](https://github.com/windkh/node-red-contrib-telegrambot/issues/450#issuecomment-2978...) on V17.4.13 surfaced a **sibling wedge** on a different code path that V17.4.14 doesn't cover.

## The bug

Trigger: any non-retryable bot error. WJ4IoT's deterministic repro was a Markdown-mode message containing an unescaped `_` — Telegram rejects with `ETELEGRAM: 400 Bad Request: can't parse entities`. Sequence:

1. `bot.sendMessage(..., { parse_mode: 'Markdown' })` rejects
2. `.catch(processError(...))` runs
3. `processError` checks 429 / ENOTFOUND / ECONNRESET — none match → `retry = false`
4. Non-retry branch: logs `node.error()`, invokes `nodeDone(errorMessage)` if present
5. **`processNext(chatId)` is never called** → `processing[chatId]` stays `true` forever
6. Every subsequent send to that chat queues but never starts

Same wedge symptom as V17.4.14's empty-content drop, different trigger. WJ4IoT's workaround (strip Markdown special chars from content via regex) prevents the trigger but doesn't fix the underlying bug.

## Fix

Add `node.queueManager.processNext(chatId)` after the non-retry branch's logging. The retry branch uses `repeatProcessMessage` which re-runs the same message; a successful retry's `processResult` then advances naturally — only the give-up path needed the explicit advance.

## Tests

1 new mocha regression case using a bot stub whose first `sendMessage` rejects with the canonical Markdown-parse-error string and subsequent calls succeed. Pre-fix the second send wouldn't reach the bot. Post-fix both calls land and `processing[123]` is `false`. 242 passing.

## Release plan

Ship as **V17.4.15** to npm's `latest` once merged. The V18 beta line already carries the same fix in [`50194c2`](https://github.com/windkh/node-red-contrib-telegrambot/commit/50194c2); both lines stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)