### PR TITLE
17.4.16: close 3 remaining queue-wedge sites via systematic audit (#450 audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [17.4.16] - 2026-06-16
+### Close the three remaining queue-wedge sites in `out-node.js` surfaced by a systematic audit of `processMessage`'s no-dispatch branches (#450 audit). V17.4.14 fixed the `hasContent` empty-content drop; V17.4.15 fixed `processError`'s non-retryable branch. Audit found three more sibling sites with identical shape — warn-but-don't-dispatch, leaving `processing[chatId]` stuck `true` forever:
+
+### (1) `case 'mediaGroup'` else branch when `msg.payload.content` is not an array — warns "msg.payload.content for mediaGroup is not an array of mediaItem", no dispatch. (2) `default` case when `type` isn't a method on the bot — warns "msg.payload.type is not supported", no dispatch. (3) The else of `if (msg.payload.type)` — warns "msg.payload.type is empty", no dispatch. All three would wedge the chatId's queue if hit on a chat that has more messages queued behind.
+
+### Same fix shape as the prior two: add `node.queueManager.processNext(chatId)` after each warn so the queue head is released. 3 new mocha regression cases (one per branch) use the "two messages, first hits the no-dispatch path, second proves the queue advanced" pattern. 245 passing.
+
+### The audit also examined the `mediaGroup` inner validation loop. Its `break` exits the for loop but control falls THROUGH to `telegramBot.sendMediaGroup(...)` which DOES dispatch (with invalid content). Bot returns error → `processError` → queue advances. Not a wedge, just a code smell where the warn is misleading because the bot is called regardless. Left as-is; not a correctness issue and changing it would alter user-visible behaviour.
+
 # [17.4.15] - 2026-06-16
 ### Fix sibling queue-wedge in `out-node.js`'s `processError` non-retryable branch (#450 round 2). WJ4IoT's V17.4.13 retest surfaced a second wedge mechanism that V17.4.14 didn't cover. Trigger: a Markdown-mode message containing an unescaped `_` (or `*`, `[`, etc.) causes Telegram to reject with `ETELEGRAM: 400 Bad Request: can't parse entities`. `processError` matches the non-retry branch (it's not 429 / ENOTFOUND / ECONNRESET), logs `node.error()`, invokes `nodeDone()` — and never calls `queueManager.processNext(chatId)`. Same wedge symptom as V17.4.14's empty-content drop fix: `processing[chatId]` stays `true` forever, subsequent messages on that chat queue but never start. WJ4IoT's manual repro: send a message with `_` in the text, then send a plain-text message — the second one silently never sends until redeploy.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "17.4.15",
+    "version": "17.4.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-telegrambot",
-            "version": "17.4.15",
+            "version": "17.4.16",
             "license": "MIT",
             "dependencies": {
                 "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "17.4.15",
+    "version": "17.4.16",
     "description": "Telegram bot nodes for Node-RED",
     "dependencies": {
         "bluebird": "^3.7.2",

--- a/telegrambot/nodes/out-node.js
+++ b/telegrambot/nodes/out-node.js
@@ -342,6 +342,11 @@ module.exports = function (RED) {
                                         });
                                 } else {
                                     node.warn('msg.payload.content for mediaGroup is not an array of mediaItem');
+                                    // Drop-and-advance: no dispatch on this path, so the
+                                    // queue head would otherwise stay `processing: true`
+                                    // forever (#450 audit, sibling of the processError /
+                                    // hasContent fixes).
+                                    node.queueManager.processNext(chatId);
                                 }
                             }
                             break;
@@ -816,10 +821,18 @@ module.exports = function (RED) {
                             } else {
                                 // type is not supported.
                                 node.warn('msg.payload.type is not supported');
+                                // Drop-and-advance: no dispatch on this path, so the
+                                // queue head would otherwise stay `processing: true`
+                                // forever (#450 audit).
+                                node.queueManager.processNext(chatId);
                             }
                     }
                 } else {
                     node.warn('msg.payload.type is empty');
+                    // Drop-and-advance: same wedge shape as the other no-dispatch
+                    // branches — without this, a single payload with no `type`
+                    // wedges its chatId's queue (#450 audit).
+                    node.queueManager.processNext(chatId);
                 }
             } // forward
         };

--- a/test/nodes/out-node.test.js
+++ b/test/nodes/out-node.test.js
@@ -406,3 +406,120 @@ describe('telegram sender (out-node) — queue advance on non-retry processError
         });
     });
 });
+
+describe('telegram sender (out-node) — queue advance on remaining no-dispatch branches (#450 audit)', function () {
+    before(function (done) {
+        helper.startServer(done);
+    });
+
+    after(function (done) {
+        helper.stopServer(done);
+    });
+
+    afterEach(function () {
+        helper.unload();
+    });
+
+    function flow() {
+        return [
+            { id: 'b1', type: 'telegram bot', botname: 'b', updatemode: 'sendonly' },
+            { id: 's1', type: 'telegram sender', bot: 'b1', wires: [['out']] },
+            { id: 'out', type: 'helper' },
+        ];
+    }
+
+    // Each test sends two messages on the same chatId: the first hits a
+    // no-dispatch branch (would historically wedge), the second is a normal
+    // send. If queue advance is wired up correctly, the second reaches the
+    // bot stub. Pre-fix, the second silently parks behind the wedged head.
+
+    it('mediaGroup with non-array content advances the queue', function (done) {
+        helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
+            try {
+                const s = helper.getNode('s1');
+                const out = helper.getNode('out');
+                const cfg = helper.getNode('b1');
+                const record = [];
+                cfg.getTelegramBot = function () {
+                    return makeBotStub(record);
+                };
+                s.warn = function () {};
+
+                out.on('input', function (msg) {
+                    try {
+                        expect(msg.payload.sentMessageId).to.equal(999);
+                        expect(s.queueManager.processing.get(789)).to.equal(false);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+
+                s.receive({ payload: { chatId: 789, type: 'mediaGroup', content: 'not-an-array' } });
+                s.receive({ payload: { chatId: 789, type: 'message', content: 'recovered' } });
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('unknown msg.payload.type (no such bot method) advances the queue', function (done) {
+        helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
+            try {
+                const s = helper.getNode('s1');
+                const out = helper.getNode('out');
+                const cfg = helper.getNode('b1');
+                const record = [];
+                cfg.getTelegramBot = function () {
+                    return makeBotStub(record);
+                };
+                s.warn = function () {};
+
+                out.on('input', function (msg) {
+                    try {
+                        expect(msg.payload.sentMessageId).to.equal(999);
+                        expect(s.queueManager.processing.get(789)).to.equal(false);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+
+                s.receive({ payload: { chatId: 789, type: 'noSuchMethodOnBot', content: 'whatever' } });
+                s.receive({ payload: { chatId: 789, type: 'message', content: 'recovered' } });
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('missing msg.payload.type advances the queue', function (done) {
+        helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
+            try {
+                const s = helper.getNode('s1');
+                const out = helper.getNode('out');
+                const cfg = helper.getNode('b1');
+                const record = [];
+                cfg.getTelegramBot = function () {
+                    return makeBotStub(record);
+                };
+                s.warn = function () {};
+
+                out.on('input', function (msg) {
+                    try {
+                        expect(msg.payload.sentMessageId).to.equal(999);
+                        expect(s.queueManager.processing.get(789)).to.equal(false);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                });
+
+                s.receive({ payload: { chatId: 789, content: 'whatever' } });
+                s.receive({ payload: { chatId: 789, type: 'message', content: 'recovered' } });
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

V17.4.14 and V17.4.15 each fixed one queue-wedge mechanism in `out-node.js` (`hasContent` empty-content drop; `processError` non-retryable branch). A systematic audit of every code path in `processMessage` for the "we're done with this message but never called processNext" anti-pattern surfaced three more sibling sites that share the same fix shape.

## The three sites

All warn-but-don't-dispatch — `processing[chatId]` stays `true` forever, subsequent messages on that chat silently park behind the wedged head:

1. **`case 'mediaGroup'` else branch** when `msg.payload.content` is not an array. Warns `"msg.payload.content for mediaGroup is not an array of mediaItem"`. No dispatch.
2. **`default` case** when `type` isn't a method on the bot. Warns `"msg.payload.type is not supported"`. No dispatch.
3. **`else` of `if (msg.payload.type)`** — payload with no `type` field at all. Warns `"msg.payload.type is empty"`. No dispatch.

## Fix

Same pattern as V17.4.14 and V17.4.15: add `node.queueManager.processNext(chatId)` after each warn so the queue head is released.

## Also examined (not a wedge)

`case 'mediaGroup'`'s inner validation loop (`if (typeof mediaItem.type !== 'string')` / `if (mediaItem.media === undefined)`) `break`s out of the for loop on validation failure — but control falls THROUGH to `telegramBot.sendMediaGroup(...)` which DOES dispatch (with the invalid content). Bot returns error → `processError` → queue advances. Not a wedge; just a misleading warn since the bot is called anyway. Left as-is to preserve user-visible behaviour.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 245 passing (was 242; +3 new regression cases)
- [x] Each test uses the same "two messages, first hits the no-dispatch path, second proves the queue advanced" pattern as the V17.4.14 / V17.4.15 regression tests

## Release plan

Ship as **V17.4.16** to npm's `latest` once merged. The V18 beta line already carries the same three fixes in commit [`d0d2875`](https://github.com/windkh/node-red-contrib-telegrambot/commit/d0d2875); both lines stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)