### PR TITLE
ci(publish): modernize publish workflow actions and Node version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 12
+                  node-version: 20
             - run: npm ci
             - run: npm run lint
 
@@ -22,10 +22,10 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 12
+                  node-version: 20
                   registry-url: https://registry.npmjs.org/
             - run: npm ci
             # GitHub releases flagged "pre-release" publish to the `beta`
@@ -40,10 +40,10 @@ jobs:
     #   needs: build
     #   runs-on: ubuntu-latest
     #   steps:
-    #     - uses: actions/checkout@v2
-    #     - uses: actions/setup-node@v1
+    #     - uses: actions/checkout@v4
+    #     - uses: actions/setup-node@v4
     #       with:
-    #         node-version: 12
+    #         node-version: 20
     #         registry-url: https://npm.pkg.github.com/
     #     - run: npm ci
     #     - run: npm publish


### PR DESCRIPTION
## Why
The publish workflow still pinned `actions/checkout@v2` + `actions/setup-node@v1`, which GitHub is force-migrating to Node 24 (started **2026-06-16**) and removing the Node 20 runtime for on **2026-09-16**. After that these actions stop working — so the next stable release (e.g. V18.0.0) would fail to publish. The V18.0.0-beta.1 run surfaced the deprecation annotation.

## What
- `actions/checkout@v2` → `@v4`, `actions/setup-node@v1` → `@v4` (matches the already-modern `ci.yml` and `dependency-review.yml`).
- Runner Node `12` → `20`, matching `engines.node >= 20` and silencing EBADENGINE warnings from modern transitive deps (undici@7) during `npm ci`.
- Same bump applied to the commented-out GPR block for consistency.

Publish only uploads the tarball, so package contents are unchanged. The `--tag beta` prerelease conditional is untouched.