### PR TITLE
fix(close): `_abort=true` + `cancel:true` to fix 15s deploy hang (#463)

### DIFF
--- a/telegrambot/nodes/bot-node.js
+++ b/telegrambot/nodes/bot-node.js
@@ -895,11 +895,30 @@ module.exports = function (RED) {
                     // V17.3.0 dropped the explicit `.cancel()` in favour of cancel:true, and
                     // V17.4.4 added a `_polling = null` hack to compensate. Neither actually
                     // stopped the recursive loop. This restores the pattern that does.
+                    // V17.4.16 issue: stopPolling({cancel:false}) returns
+                    // `lastRequest.finally(() => {_abort = false})`, which waits for the
+                    // in-flight long-poll to settle. The .cancel('abortBot') above
+                    // does not propagate through @cypress/request-promise's chained
+                    // .then() promise back to the HTTP socket in all setups, so the
+                    // request runs to its natural pollTimeout (10s hardcoded). With
+                    // sibling-node cleanup overhead on a busy flow, total close time
+                    // routinely crosses Node-RED's 15s nodeCloseTimeout → "Error
+                    // stopping node: Close timed out" on every deploy.
+                    //
+                    // Fix: set _abort = true on the polling instance directly (this
+                    // is the recursive-setTimeout disarm that the comment block above
+                    // explained was the reason for picking cancel:false in V17.4.8),
+                    // then use cancel:true. The lib's stop() returns Promise.resolve()
+                    // immediately on cancel:true, so close completes without waiting.
+                    // The recursive loop is already disarmed by _abort=true, so the
+                    // 409-Conflict race that V17.3.0 hit with cancel:true alone
+                    // cannot occur.
                     const polling = self.telegramBot._polling;
+                    polling._abort = true;
                     if (polling._lastRequest && typeof polling._lastRequest.cancel === 'function') {
                         polling._lastRequest.cancel('abortBot');
                     }
-                    self.telegramBot.stopPolling({ cancel: false }).then(setStatusDisconnected, setStatusDisconnected);
+                    self.telegramBot.stopPolling({ cancel: true }).then(setStatusDisconnected, setStatusDisconnected);
                 } else if (self.telegramBot._webHook) {
                     // Telegram keeps the previously registered webhook URL on file until we tell it
                     // to drop it. Wait for deleteWebHook to complete (or fail) before tearing the

--- a/test/nodes/bot-node-restart.test.js
+++ b/test/nodes/bot-node-restart.test.js
@@ -491,14 +491,16 @@ describe('bot-node — abortBot stops polling cleanly (issue #440, V17.4.8)', fu
     function makeFakePollingBot(behaviour) {
         behaviour = behaviour || {};
         const calls = { cancel: [], stopPolling: [] };
-        const fake = {
-            _polling: {
-                _lastRequest: {
-                    cancel: function (reason) {
-                        calls.cancel.push(reason);
-                    },
+        const polling = {
+            _abort: false,
+            _lastRequest: {
+                cancel: function (reason) {
+                    calls.cancel.push(reason);
                 },
             },
+        };
+        const fake = {
+            _polling: polling,
             stopPolling: function (options) {
                 calls.stopPolling.push(options);
                 if (behaviour.stopPollingRejects) {
@@ -507,22 +509,27 @@ describe('bot-node — abortBot stops polling cleanly (issue #440, V17.4.8)', fu
                 return Promise.resolve();
             },
         };
-        return { bot: fake, calls };
+        return { bot: fake, calls, polling };
     }
 
     it('cancels in-flight _lastRequest before stopPolling resolves', function (done) {
         helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
             try {
                 const n = helper.getNode('b1');
-                const { bot, calls } = makeFakePollingBot();
+                const { bot, calls, polling } = makeFakePollingBot();
                 n.telegramBot = bot;
                 n.abortBot('test', function () {
                     try {
                         expect(calls.cancel).to.deep.equal(['abortBot']);
-                        // stopPolling MUST be called with cancel:false (the only way to set
-                        // _abort=true in the lib, which is the only way to halt the recursive
-                        // polling loop).
-                        expect(calls.stopPolling).to.deep.equal([{ cancel: false }]);
+                        // Close path sets polling._abort = true directly (disarms the
+                        // recursive setTimeout in _polling()'s .finally), then calls
+                        // stopPolling({cancel:true}) so the lib returns Promise.resolve()
+                        // immediately instead of waiting for the in-flight long-poll to
+                        // settle. The recursive loop is already disarmed by _abort=true,
+                        // so the 409-Conflict race that V17.3.0 hit with cancel:true alone
+                        // cannot occur.
+                        expect(polling._abort).to.equal(true);
+                        expect(calls.stopPolling).to.deep.equal([{ cancel: true }]);
                         expect(n.telegramBot).to.equal(null);
                         done();
                     } catch (err) {
@@ -543,7 +550,7 @@ describe('bot-node — abortBot stops polling cleanly (issue #440, V17.4.8)', fu
                 n.telegramBot = bot;
                 n.abortBot('test', function () {
                     try {
-                        expect(calls.stopPolling).to.deep.equal([{ cancel: false }]);
+                        expect(calls.stopPolling).to.deep.equal([{ cancel: true }]);
                         expect(n.telegramBot).to.equal(null);
                         done();
                     } catch (err) {
@@ -568,7 +575,7 @@ describe('bot-node — abortBot stops polling cleanly (issue #440, V17.4.8)', fu
                 n.abortBot('test', function () {
                     try {
                         expect(calls.cancel).to.deep.equal([]); // no cancel attempted
-                        expect(calls.stopPolling).to.deep.equal([{ cancel: false }]);
+                        expect(calls.stopPolling).to.deep.equal([{ cancel: true }]);
                         expect(n.telegramBot).to.equal(null);
                         done();
                     } catch (err) {
@@ -591,7 +598,7 @@ describe('bot-node — abortBot stops polling cleanly (issue #440, V17.4.8)', fu
                 n.abortBot('test', function () {
                     try {
                         expect(calls.cancel).to.deep.equal([]);
-                        expect(calls.stopPolling).to.deep.equal([{ cancel: false }]);
+                        expect(calls.stopPolling).to.deep.equal([{ cancel: true }]);
                         expect(n.telegramBot).to.equal(null);
                         done();
                     } catch (err) {


### PR DESCRIPTION
Fixes #463.

## Summary

`stopPolling({cancel:false})` returns `lastRequest.finally(...)`, waiting for the in-flight long-poll to settle. The `.cancel('abortBot')` doesn't reliably propagate through `@cypress/request-promise`'s chained `.then()` promise back to the HTTP socket, so the request runs to its natural `pollTimeout` (10s hardcoded). Combined with sibling-node cleanup overhead on a busy flow, total close time routinely crosses Node-RED's 15s `nodeCloseTimeout` → "Error stopping node: Close timed out" on every deploy.

## Fix

Set `polling._abort = true` on the polling instance directly (the recursive-setTimeout disarm that the existing comment block explained was the reason for picking `cancel:false` in V17.4.8), then use `cancel:true`. The lib's `stop()` then returns `Promise.resolve()` immediately. The recursive loop is already disarmed by `_abort=true` so the 409-Conflict race that V17.3.0 hit with `cancel:true` alone cannot occur.

```diff
                     const polling = self.telegramBot._polling;
+                    polling._abort = true;
                     if (polling._lastRequest && typeof polling._lastRequest.cancel === 'function') {
                         polling._lastRequest.cancel('abortBot');
                     }
-                    self.telegramBot.stopPolling({ cancel: false }).then(setStatusDisconnected, setStatusDisconnected);
+                    self.telegramBot.stopPolling({ cancel: true }).then(setStatusDisconnected, setStatusDisconnected);
```

Comment block above the change updated to explain why both halves are necessary.

## Tests

Updated `bot-node-restart.test.js`:
- `makeFakePollingBot` now exposes the polling instance + initialises `_abort: false`, so tests can assert `_abort = true` was set during close.
- The 3 close-path tests updated to expect `{ cancel: true }` and the new `_abort` assertion.

⚠️ **Local test environment couldn't run the suite cleanly** — mocha hits 5s timeouts on the same tests on unmodified master too (likely a Node version mismatch on my macOS dev box; the production CI matrix targets Node 20.x/22.x). The bot-node-restart tests in particular need someone with a working test env to confirm. If anything looks wrong with the assertion shape I'm happy to iterate.

## Production verification

Verified on a multi-node Node-RED 4.1.1 flow (Telegram bot + MQTT broker + TCP nodes) on RP5 / Node.js v20.19.5:

| | Before | After |
|---|---|---|
| `Stopping flows` → `Started flows` | ~12–15s (often hits 15s timeout) | <1s |
| `Error stopping node: Close timed out` | Every deploy | Never |
| Bot polling after deploy | Works | Works |
| 409 Conflicts across rapid back-to-back deploys | Not observed | Not observed |

Bot continues receiving and sending across many deploys.