### PR TITLE
fix: Invalid SOCKS proxy details were provided

### DIFF
--- a/telegrambot/nodes/bot-node.js
+++ b/telegrambot/nodes/bot-node.js
@@ -214,7 +214,7 @@ module.exports = function (RED) {
                 const socks = {
                     type: socksType,
                     host: n.sockshost,
-                    port: n.socksport,
+                    port: Number(n.socksport),
                 };
                 if (n.socksusername) socks.userId = n.socksusername;
                 if (n.sockspassword) socks.password = n.sockspassword;


### PR DESCRIPTION
I updated
https://github.com/windkh/node-red-contrib-telegrambot/blob/master/MIGRATION.md
to 18.0.0

My socks proxy works well
```
curl --socks5-hostname 127.0.0.1:1081 https://icanhazip.com
a.b.c.d
```

But Telegram bot does not work
```
15 Jul 10:01:25 - [warn] [telegram bot:448c0a7b53caf8a7] Polling error --> Trying again.
15 Jul 10:01:28 - [warn] [telegram bot:448c0a7b53caf8a7] Invalid SOCKS proxy details were provided.
15 Jul 10:01:28 - [warn] [telegram bot:448c0a7b53caf8a7] [TypeError: fetch failed] {
  code: 'EFATAL',
  name: 'FatalError',
  cause: [TypeError: fetch failed] {
    [cause]: SocksClientError: Invalid SOCKS proxy details were provided.
        at validateSocksClientOptions (/config/node_modules/socks/src/common/helpers.ts:47:11)
        at /config/node_modules/socks/src/client/socksclient.ts:105:35
        at new Promise (<anonymous>)
        at SocksClient.createConnection (/config/node_modules/socks/src/client/socksclient.ts:102:12)
        at /config/node_modules/fetch-socks/index.js:47:53
        at Client.connect (/config/node_modules/undici/lib/dispatcher/client.js:241:37)
        at connect (/config/node_modules/undici/lib/dispatcher/client.js:461:23)
        at _resume (/config/node_modules/undici/lib/dispatcher/client.js:644:7)
        at resume (/config/node_modules/undici/lib/dispatcher/client.js:574:3)
        at /config/node_modules/undici/lib/dispatcher/client.js:348:28 {
      options: {
        command: 'connect',
        proxy: { type: 4, host: 'localhost', port: '1081' },
        timeout: 10000,
        destination: { host: 'api.telegram.org', port: 443 },
        existing_socket: undefined
      }
    }
  }
}
```

The problem is the port is being passed as a string. The error comes from the socks package validation.