### PR TITLE
chore: run node-red-standards from a local devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "19.0.0",
+    "version": "19.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-red-contrib-telegrambot",
-            "version": "19.0.0",
+            "version": "19.0.1",
             "license": "MIT",
             "dependencies": {
                 "fetch-socks": "^1.3.3",
@@ -22,6 +22,7 @@
                 "husky": "^9.1.7",
                 "node-red": "^5.0.1",
                 "node-red-node-test-helper": "^0.3.4",
+                "node-red-standards": "github:windkh/node-red-standards",
                 "prettier": "^3.9.6",
                 "proxyquire": "^2.1.3"
             },
@@ -3803,6 +3804,18 @@
             },
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/node-red-standards": {
+            "version": "0.5.0",
+            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "nrstd": "bin/nrstd.mjs"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/node-telegram-bot-api": {
@@ -10060,6 +10073,11 @@
                 "stoppable": "^1.1.0",
                 "supertest": "^7.1.4"
             }
+        },
+        "node-red-standards": {
+            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "dev": true,
+            "from": "node-red-standards@github:windkh/node-red-standards"
         },
         "node-telegram-bot-api": {
             "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3807,8 +3807,8 @@
             }
         },
         "node_modules/node-red-standards": {
-            "version": "0.5.0",
-            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "version": "0.5.1",
+            "resolved": "git+ssh://git@github.com/windkh/node-red-standards.git#f3982d0a9447df04a6074bf654aca39e174a5fc3",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -10075,7 +10075,7 @@
             }
         },
         "node-red-standards": {
-            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#e4bd2440264cea0c42ee6de10ebd7f62a179629d",
+            "version": "git+ssh://git@github.com/windkh/node-red-standards.git#f3982d0a9447df04a6074bf654aca39e174a5fc3",
             "dev": true,
             "from": "node-red-standards@github:windkh/node-red-standards"
         },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "coverage": "c8 npm test",
-        "coverage:check": "c8 --check-coverage npm test"
+        "coverage:check": "c8 --check-coverage npm test",
+        "standards:audit": "nrstd audit",
+        "standards:sync": "nrstd sync"
     },
     "husky": {
         "hooks": {
@@ -74,15 +76,16 @@
     "author": "Karl-Heinz Wind",
     "license": "MIT",
     "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "c8": "^12.0.0",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.8.0",
         "husky": "^9.1.7",
         "node-red": "^5.0.1",
         "node-red-node-test-helper": "^0.3.4",
+        "node-red-standards": "github:windkh/node-red-standards",
         "prettier": "^3.9.6",
-        "proxyquire": "^2.1.3",
-        "@eslint/js": "^10.0.1",
-        "globals": "^17.8.0"
+        "proxyquire": "^2.1.3"
     }
 }


### PR DESCRIPTION
### Why

`nrstd audit` was only reachable through `npx github:windkh/node-red-standards`, which refetches on every call and needs network. Declaring the standard as a devDependency makes `npm run standards:audit` work offline against the installed copy, and lets dependabot keep the reference moving — it already does this for the repos that had added it by hand.

The specifier is deliberately the moving `github:windkh/node-red-standards` and **not** a pinned commit. `node-red-contrib-ntrip` pinned a commit tarball and silently stopped receiving the standard for three releases while still reporting a clean audit against the frozen copy; `node-red-standards` 0.5.0 now treats any other specifier for itself as drift.

Worth knowing for the future: `npm install` does **not** re-resolve a git dependency whose existing lockfile entry already satisfies the specifier — only `npm update` or dependabot moves it. An unpinned specifier is therefore not by itself enough to keep a repo current. (`node-red-contrib-shelly` had an unpinned specifier and a lockfile stuck two releases back.)

### Contents

- `devDependencies["node-red-standards"] = "github:windkh/node-red-standards"`
- `scripts.standards:audit` / `scripts.standards:sync` — without these the devDependency is decoration
- lockfile pointing at 0.5.1

`npm pkg set` also normalised the `devDependencies` key order alphabetically — that is the four-line reordering in the diff, not a content change.

Verified locally: lint, format:check, 303 tests. Audit 18/18.
