### PR TITLE
fix(test): parse the multipart boundary with a character class

### DIFF
--- a/test/fixtures/telegram-mock.js
+++ b/test/fixtures/telegram-mock.js
@@ -116,7 +116,13 @@ function startMock() {
             } else if (ct.includes('application/x-www-form-urlencoded')) {
                 body = parseFormBody(raw);
             } else if (ct.includes('multipart/form-data')) {
-                const boundary = (ct.match(/boundary=(.+)$/) || [])[1];
+                // Character class, not `(.+)$`. Two reasons, and the correctness one is the
+                // stronger: a Content-Type may carry parameters after the boundary
+                // (`multipart/form-data; boundary=abc; charset=utf-8`), and `(.+)$` swallows
+                // them into the boundary. It is also linear -- `(.+)$` backtracks
+                // quadratically when the anchor fails, which is what CodeQL reports as
+                // js/polynomial-redos.
+                const boundary = (ct.match(/boundary=([^;\s]+)/) || [])[1];
                 if (boundary) body = parseMultipart(raw, boundary);
             }
 


### PR DESCRIPTION
Closes the `js/polynomial-redos` code-scanning alert (#4, high, open since 2026-05-12) in `test/fixtures/telegram-mock.js`.

```diff
-const boundary = (ct.match(/boundary=(.+)$/) || [])[1];
+const boundary = (ct.match(/boundary=([^;\s]+)/) || [])[1];
```

## The correctness reason is the stronger one

`(.+)$` is greedy to the end of the string, but a `Content-Type` may carry parameters *after* the boundary. So:

| Content-Type | `(.+)$` | `([^;\s]+)` |
| --- | --- | --- |
| `multipart/form-data; boundary=abc123` | `abc123` | `abc123` |
| `multipart/form-data; boundary=abc123; charset=utf-8` | **`abc123; charset=utf-8`** | `abc123` |

The boundary then goes into `Buffer.from('--' + boundary)` in `parseMultipart`, so a request with a trailing parameter would fail to split — silently, as an empty body. No current test sends one, which is why this never showed up.

## The ReDoS is real, but not reachable here

Worth being precise rather than just quoting the alert. `(.+)$` backtracks quadratically only when the anchor *fails*, which needs a `\n` mid-string. Measured, with `'boundary=a'.repeat(k) + '\n' + 'x'`:

| k | length | `(.+)$` | `([^;\s]+)` |
| --: | --: | --: | --: |
| 1000 | 10 kB | 14.4 ms | 0.09 ms |
| 2000 | 20 kB | 42.8 ms | 0.05 ms |
| 4000 | 40 kB | 166.0 ms | 0.07 ms |
| 8000 | 80 kB | 719.3 ms | 0.14 ms |

Clean 4× per doubling. But the input is `req.headers['content-type']` from Node's own HTTP server, which rejects headers containing newlines — so the pathological shape cannot arrive through the server, and this is a mock used only by the test suite in the first place. The alert is a true positive about the regex and a false positive about the exposure.

Fixing it anyway: the correctness bug above is real, the linear form is not harder to read, and an open high-severity alert that has to be re-triaged by every reader costs more than the two-character change.

Verified: lint, format:check and all 303 tests pass.
