### PR TITLE
fix: don't lose messages when a route change black-holes the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [19.0.4] - 2026-09-11
+
+### Retry the sender's network failures instead of reporting and dropping the message. `processError` classified a failure by searching the stringified exception for `ENOTFOUND` or `ECONNRESET`. Since V18 moved the transport to `fetch`, that string never contains either: node-telegram-bot-api reports every transport failure as `FatalError: EFATAL: fetch failed`, Node's fetch wraps the real failure as `TypeError: fetch failed`, and the code that says what actually happened — `ECONNRESET`, `ENOTFOUND`, `UND_ERR_HEADERS_TIMEOUT` — sits two levels down in `.cause`. Both checks had therefore been dead since 18.0.0, and *every* connection failure took the non-retry path: `node.error`, and the message gone. The 429/flood-wait branch was unaffected, because `ETELEGRAM` messages do carry their text at the top level.
+
+### Classification now walks the cause chain (new `lib/transient-errors.js`, `findTransientErrorCode`), and covers the whole family rather than two members of it: `ECONNRESET`, `ECONNREFUSED`, `ECONNABORTED`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `EHOSTDOWN`, `EHOSTUNREACH`, `ENETDOWN`, `ENETRESET`, `ENETUNREACH`, `EPIPE`, plus undici's `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT` and `UND_ERR_BODY_TIMEOUT`. These are all the same transient fault — the request never reached Telegram, or its answer never came back — and all deserve the existing `retryDelayErrorNoConnection` treatment. `AggregateError.errors` is walked too, which is the shape a dual-stack host produces when both its A and AAAA addresses fail.
+
+### `UND_ERR_CLOSED` and `UND_ERR_DESTROYED` are deliberately not retried: they mean the dispatcher was closed by us (node close, redeploy, `scheduleRestart`), where a retry would fight the shutdown that caused it. Errors Telegram answered with (`ETELEGRAM`) keep taking the non-retry path, so a malformed-Markdown or bad-chat-id failure still surfaces immediately instead of looping. The status text names the code that was found (`ECONNRESET: retrying in 10s`) rather than the `EFATAL` wrapper it arrived in.
+
+### This pairs with the 20 s headers timeout added in 19.0.3. That change is what turns a socket black-holed by a WAN failover into a reportable error; without this one, the error it produces would have been reported and the message dropped.
+
 # [19.0.3] - 2026-09-11
 
 ### Arm a 20 s response-header deadline on every Bot API call. The bot's undici dispatcher is now built with `headersTimeout: 20000` instead of undici's 300 s default, so a request on a keep-alive socket that has stopped delivering fails in 20 s rather than five minutes. This is the normal outcome of a WAN failover or an IP change: the established flow is black-holed, no RST is ever delivered, and the request never settles. While it hangs, `telegramPolling._polling()` does not reschedule and emits neither `polling_error` nor `error`, so `recordPollingError`, `scheduleRestart` and `destroyDispatcher` — the #440 / #442 recovery machinery — are never reached; the bot shows a green "polling" status while every sender queues behind the same dead socket, and only a redeploy clears it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [19.0.3] - 2026-09-11
+
+### Arm a 20 s response-header deadline on every Bot API call. The bot's undici dispatcher is now built with `headersTimeout: 20000` instead of undici's 300 s default, so a request on a keep-alive socket that has stopped delivering fails in 20 s rather than five minutes. This is the normal outcome of a WAN failover or an IP change: the established flow is black-holed, no RST is ever delivered, and the request never settles. While it hangs, `telegramPolling._polling()` does not reschedule and emits neither `polling_error` nor `error`, so `recordPollingError`, `scheduleRestart` and `destroyDispatcher` — the #440 / #442 recovery machinery — are never reached; the bot shows a green "polling" status while every sender queues behind the same dead socket, and only a redeploy clears it.
+
+### The deadline is on the response headers, not the request, so it is not a cap on upload duration: `headersTimeout` starts once the request body has been written, and a large photo or video over a slow uplink is unaffected (covered by a regression test). It sits above `pollTimeout` (10 s) with room to spare, since `getUpdates` long-polls for that long before Telegram writes the response headers. `connectTimeout` and `bodyTimeout` keep undici's defaults. The setting rides on the agent options, so SOCKS-proxied bots get it too.
+
 # [19.0.2] - 2026-08-27
 
 ### Fix duplicate messages out of the receiver, event and command nodes in **webhook** mode (#510). Every one of these nodes starts twice: once from its own constructor, and once more when the config node broadcasts `'started'`. Both paths attached listeners, so a single Telegram update left the node twice — identical `message_id`, a fresh `_msgid` each — while polling was unaffected because its creation path broadcasts no `'started'` at all. The webhook path does, from inside the `setWebhook()` promise, which resolves *after* the receiver nodes have been constructed and have already started themselves; nothing precedes that broadcast with a `'stopped'`, so nothing detached first. Introduced in 17.3.1 by the fix that made the webhook-success branch broadcast its status — without it, downstream nodes stayed stuck at "not connected" — which exposed a double-start that had been latent and harmless since before 17.1.3.

--- a/doc/architecture/behavioural-design.md
+++ b/doc/architecture/behavioural-design.md
@@ -84,11 +84,13 @@ processMessage(chatId, msg, ...)
 telegramBot.sendXxx(args)
       │
       ▼ .catch
-      ▼            ┌───────────────────────────┐
-processError ─────►│ retry  on 429 / ENOTFOUND │
-      │           │ ECONNRESET — queueManager   │
-      │           │ .repeatProcessMessage       │
-      │           └───────────────────────────┘
+      ▼            ┌─────────────────────────────┐
+processError ─────►│ retry on 429, or a transient │
+      │           │ network code found in the    │
+      │           │ cause chain (lib/transient-  │
+      │           │ errors) — queueManager       │
+      │           │ .repeatProcessMessage        │
+      │           └─────────────────────────────┘
       ▼ .then
 processResult
       │

--- a/doc/architecture/structural-design.md
+++ b/doc/architecture/structural-design.md
@@ -146,7 +146,7 @@ The sender node is the only consumer.
                          telegramBot.sendXxx(...)
                               │
                               ▼ .catch / .then
-                         processError(...) — retry on 429/ENOTFOUND/ECONNRESET
+                         processError(...) — retry on 429 / transient network
                          processResult(...)   — emit msg + processNext(chatId)
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "19.0.3",
+    "version": "19.0.4",
     "description": "Telegram bot nodes for Node-RED",
     "files": [
         "telegrambot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-telegrambot",
-    "version": "19.0.2",
+    "version": "19.0.3",
     "description": "Telegram bot nodes for Node-RED",
     "files": [
         "telegrambot",

--- a/telegrambot/lib/transient-errors.js
+++ b/telegrambot/lib/transient-errors.js
@@ -1,0 +1,82 @@
+// Decides whether an error thrown by a Bot API call is a transient network
+// failure — one where the request never reached Telegram, or its answer never
+// came back — as opposed to a request Telegram received and actively rejected.
+// Repeating the first kind is the only way the message is ever delivered;
+// repeating the second would just fail again.
+//
+// The decision has to walk the cause chain. node-telegram-bot-api v1.x reports
+// every transport failure as `FatalError: EFATAL: fetch failed`, and Node's
+// fetch in turn wraps the real failure as `TypeError: fetch failed`, so the code
+// that says what actually happened sits two levels down in `.cause`:
+//
+//     FatalError  EFATAL: fetch failed          code = EFATAL
+//       └ TypeError  fetch failed               code = undefined
+//           └ Error  read ECONNRESET            code = ECONNRESET
+//
+// Matching against the stringified top-level error therefore never sees the
+// code. A host that resolves to both an A and an AAAA record fails as an
+// AggregateError instead, with one entry per address, so `.errors` is walked as
+// well as `.cause`.
+
+// Depth bound for the walk, mirroring lib/error-chain.js. Real chains are three
+// or four deep; the bound keeps the walk total over whatever a library hands us.
+const MAX_DEPTH = 10;
+
+// Codes that mean "the connection failed, try again": Node's syscall and DNS
+// codes, plus undici's own for a socket that closed under the request or a peer
+// that stopped answering.
+//
+// UND_ERR_CLOSED and UND_ERR_DESTROYED are deliberately absent. They mean the
+// dispatcher was closed by us — a redeploy, a node close, or scheduleRestart —
+// where a retry would fight the shutdown it is reacting to.
+const TRANSIENT_CODES = new Set([
+    'ECONNABORTED',
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'EAI_AGAIN',
+    'EHOSTDOWN',
+    'EHOSTUNREACH',
+    'ENETDOWN',
+    'ENETRESET',
+    'ENETUNREACH',
+    'ENOTFOUND',
+    'EPIPE',
+    'ETIMEDOUT',
+    'UND_ERR_BODY_TIMEOUT',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_SOCKET',
+]);
+
+// Returns the first transient code found anywhere in the error's cause chain, or
+// null when the error is not a transient network failure. The returned code is
+// what the caller reports to the user, so it names the actual fault
+// (`ECONNRESET`) rather than the wrapper it arrived in (`EFATAL`).
+function findTransientErrorCode(error) {
+    const seen = new Set();
+    const pending = [{ error: error, depth: 0 }];
+    let found = null;
+    while (pending.length > 0 && found === null) {
+        const current = pending.shift();
+        const candidate = current.error;
+        const walkable = candidate && typeof candidate === 'object' && !seen.has(candidate);
+        if (walkable && current.depth <= MAX_DEPTH) {
+            seen.add(candidate);
+            if (typeof candidate.code === 'string' && TRANSIENT_CODES.has(candidate.code)) {
+                found = candidate.code;
+            } else {
+                if (Array.isArray(candidate.errors)) {
+                    candidate.errors.forEach(function (inner) {
+                        pending.push({ error: inner, depth: current.depth + 1 });
+                    });
+                }
+                if (candidate.cause) {
+                    pending.push({ error: candidate.cause, depth: current.depth + 1 });
+                }
+            }
+        }
+    }
+    return found;
+}
+
+module.exports = { findTransientErrorCode, TRANSIENT_CODES };

--- a/telegrambot/nodes/bot-node.js
+++ b/telegrambot/nodes/bot-node.js
@@ -67,6 +67,26 @@ module.exports = function (RED) {
     const POLLING_ERROR_THRESHOLD = 5;
     const POLLING_ERROR_WINDOW_MS = 60000;
 
+    // Response-header deadline for every Bot API call, applied to the bot's undici
+    // dispatcher (see buildDispatcherOptions).
+    //
+    // undici's default headersTimeout is 300 s, so a keep-alive socket that dies
+    // silently is only noticed five minutes later. That is the normal outcome of a
+    // WAN failover or an IP change: the old flow is black-holed, no RST is ever
+    // delivered, and an in-flight request simply never settles. Until the timer
+    // expires telegramPolling._polling() does not reschedule and emits no
+    // 'polling_error' / 'error', so recordPollingError, scheduleRestart and
+    // destroyDispatcher -- the #440 / #442 recovery machinery -- are never reached:
+    // the bot keeps a green "polling" status while every sender queues behind the
+    // same dead socket.
+    //
+    // headersTimeout only counts while we are waiting for a response, not while the
+    // request body is being written, so this is not a cap on upload duration -- a
+    // large photo or video over a slow uplink is unaffected. It must stay comfortably
+    // above pollTimeout (10 s), because getUpdates long-polls for that long before
+    // Telegram writes the response headers.
+    const REQUEST_HEADERS_TIMEOUT_MS = 20000;
+
     // --------------------------------------------------------------------------------------------
 
     const botsByToken = {};
@@ -206,7 +226,7 @@ module.exports = function (RED) {
         // V17.4.13 #442 defence is preserved via close+rebuild on
         // `scheduleRestart`.
         this.buildDispatcherOptions = function () {
-            const agent = { keepAliveTimeout: 4000 };
+            const agent = { keepAliveTimeout: 4000, headersTimeout: REQUEST_HEADERS_TIMEOUT_MS };
             if (self.addressFamily === 4 || self.addressFamily === 6) {
                 agent.connect = { family: self.addressFamily };
             }

--- a/telegrambot/nodes/out-node.js
+++ b/telegrambot/nodes/out-node.js
@@ -5,6 +5,7 @@ module.exports = function (RED) {
     const QueueManager = require('../lib/queue-manager.js');
     const safeStringify = require('../lib/safe-stringify.js');
     const { migrateLegacyOptions } = require('../lib/legacy-options.js');
+    const { findTransientErrorCode } = require('../lib/transient-errors.js');
 
     // Methods the `callApi` raw-API escape hatch refuses to invoke: the
     // connection/polling lifecycle, webhook (de)registration, and the
@@ -195,18 +196,16 @@ module.exports = function (RED) {
                 retryAfter = exception.response.body.parameters.retry_after || node.retryDelayError429;
                 retry = true;
             } else {
-                const errorNotFound = String(exception).includes('ENOTFOUND');
-                if (errorNotFound) {
-                    retryReason = 'ENOTFOUND';
+                // Any failure that kept the request from completing is worth
+                // repeating, not just the two codes this used to name. The code
+                // is found by walking the cause chain: node-telegram-bot-api
+                // reports `EFATAL: fetch failed` and the real one sits below it
+                // (see lib/transient-errors.js).
+                const transientCode = findTransientErrorCode(exception);
+                if (transientCode) {
+                    retryReason = transientCode;
                     retryAfter = node.retryDelayErrorNoConnection;
                     retry = true;
-                } else {
-                    const errorConnectionReset = String(exception).includes('ECONNRESET');
-                    if (errorConnectionReset) {
-                        retryReason = 'ECONNRESET';
-                        retryAfter = node.retryDelayErrorNoConnection;
-                        retry = true;
-                    }
                 }
             }
 

--- a/test/lib/transient-errors.test.js
+++ b/test/lib/transient-errors.test.js
@@ -1,0 +1,114 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const TelegramBot = require('node-telegram-bot-api').default;
+const { findTransientErrorCode } = require('../../telegrambot/lib/transient-errors');
+
+// The shape node-telegram-bot-api produces for a transport failure: a FatalError
+// wrapping fetch's TypeError wrapping the syscall error that carries the code.
+function wrapped(code, message) {
+    const leaf = new Error(message);
+    leaf.code = code;
+    const fetchFailure = new TypeError('fetch failed', { cause: leaf });
+    const fatal = new Error('EFATAL: fetch failed');
+    fatal.code = 'EFATAL';
+    fatal.cause = fetchFailure;
+    return fatal;
+}
+
+describe('transient-errors — findTransientErrorCode', function () {
+    it('finds the syscall code two levels down the cause chain', function () {
+        assert.strictEqual(findTransientErrorCode(wrapped('ECONNRESET', 'read ECONNRESET')), 'ECONNRESET');
+    });
+
+    it('reports the underlying code, not the EFATAL wrapper it arrived in', function () {
+        const error = wrapped('ENOTFOUND', 'getaddrinfo ENOTFOUND api.telegram.org');
+        assert.strictEqual(findTransientErrorCode(error), 'ENOTFOUND');
+        assert.notStrictEqual(findTransientErrorCode(error), 'EFATAL');
+    });
+
+    it("does not appear in the top-level error's text, which is why the chain is walked", function () {
+        // Guards the assumption the whole module exists for: the pre-19.0.4 check
+        // was String(exception).includes('ECONNRESET') against exactly this error.
+        const error = wrapped('ECONNRESET', 'read ECONNRESET');
+        assert.strictEqual(String(error).includes('ECONNRESET'), false);
+        assert.strictEqual(findTransientErrorCode(error), 'ECONNRESET');
+    });
+
+    it('recognises undici timeouts and closed sockets', function () {
+        assert.strictEqual(
+            findTransientErrorCode(wrapped('UND_ERR_HEADERS_TIMEOUT', 'Headers Timeout Error')),
+            'UND_ERR_HEADERS_TIMEOUT'
+        );
+        assert.strictEqual(findTransientErrorCode(wrapped('UND_ERR_SOCKET', 'other side closed')), 'UND_ERR_SOCKET');
+        assert.strictEqual(
+            findTransientErrorCode(wrapped('UND_ERR_CONNECT_TIMEOUT', 'Connect Timeout Error')),
+            'UND_ERR_CONNECT_TIMEOUT'
+        );
+    });
+
+    it('walks AggregateError entries, as a dual-stack host produces', function () {
+        // Both the A and the AAAA address failed; fetch reports one entry each.
+        const v6 = new Error('connect ENETUNREACH 2001:67c:4e8::1:443');
+        v6.code = 'ENETUNREACH';
+        const v4 = new Error('connect ECONNREFUSED 149.154.167.220:443');
+        v4.code = 'ECONNREFUSED';
+        const aggregate = new AggregateError([v6, v4], 'all addresses failed');
+        const fatal = new Error('EFATAL: fetch failed');
+        fatal.code = 'EFATAL';
+        fatal.cause = new TypeError('fetch failed', { cause: aggregate });
+        assert.ok(['ENETUNREACH', 'ECONNREFUSED'].includes(findTransientErrorCode(fatal)));
+    });
+
+    it('returns null for an error Telegram actually answered with', function () {
+        // ETELEGRAM means the request arrived and was rejected on its merits —
+        // a malformed Markdown entity, a bad chat id. Repeating it changes nothing.
+        const telegramError = new Error("ETELEGRAM: 400 Bad Request: can't parse entities");
+        telegramError.code = 'ETELEGRAM';
+        assert.strictEqual(findTransientErrorCode(telegramError), null);
+    });
+
+    it('returns null when the dispatcher was closed by us', function () {
+        // A redeploy or scheduleRestart closes the dispatcher; retrying would
+        // fight the shutdown that caused the error.
+        assert.strictEqual(findTransientErrorCode(wrapped('UND_ERR_CLOSED', 'The client is closed')), null);
+        assert.strictEqual(findTransientErrorCode(wrapped('UND_ERR_DESTROYED', 'The client is destroyed')), null);
+    });
+
+    it('tolerates null, strings and cyclic chains', function () {
+        assert.strictEqual(findTransientErrorCode(null), null);
+        assert.strictEqual(findTransientErrorCode('ECONNRESET'), null);
+        const a = new Error('a');
+        const b = new Error('b');
+        a.cause = b;
+        b.cause = a;
+        assert.strictEqual(findTransientErrorCode(a), null);
+    });
+
+    it('finds the code in an error the library really threw', async function () {
+        // Not a hand-built shape: a real send against a server that resets the
+        // connection, through the real node-telegram-bot-api transport. If the
+        // library ever changes how it wraps transport failures, this fails.
+        const server = http.createServer(function (req) {
+            req.socket.resetAndDestroy();
+        });
+        await new Promise(function (resolve) {
+            server.listen(0, '127.0.0.1', resolve);
+        });
+        const bot = new TelegramBot('123:fake', {
+            baseApiUrl: 'http://127.0.0.1:' + server.address().port,
+        });
+        let thrown = null;
+        try {
+            await bot.sendMessage(1, 'hello');
+        } catch (e) {
+            thrown = e;
+        } finally {
+            server.closeAllConnections();
+            server.close();
+        }
+        assert.ok(thrown);
+        assert.strictEqual(String(thrown).includes('ECONNRESET'), false);
+        assert.strictEqual(findTransientErrorCode(thrown), 'ECONNRESET');
+    });
+});

--- a/test/lib/undici-pool.test.js
+++ b/test/lib/undici-pool.test.js
@@ -1,5 +1,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const http = require('node:http');
+const { Readable } = require('node:stream');
 const { Agent } = require('undici');
 const { buildDispatcher, closeDispatcher } = require('../../telegrambot/lib/undici-pool');
 
@@ -93,6 +95,85 @@ describe('undici-pool', function () {
         it('tolerates a dispatcher without a close method', async function () {
             await closeDispatcher({});
             assert.strictEqual(true, true);
+        });
+    });
+
+    describe('headers timeout', function () {
+        // bot-node passes agent.headersTimeout so a socket black-holed by a WAN
+        // failover surfaces as an error the retry/recovery paths can act on,
+        // instead of sitting on undici's 300 s default. These two tests pin the
+        // behaviour that makes the setting safe: it fires when no response is
+        // coming, and it does not fire while we are still uploading.
+
+        function listen(server) {
+            return new Promise(function (resolve) {
+                server.listen(0, '127.0.0.1', function () {
+                    resolve('http://127.0.0.1:' + server.address().port);
+                });
+            });
+        }
+
+        function shutdown(server) {
+            server.closeAllConnections();
+            server.close();
+        }
+
+        it('rejects a black-holed request instead of hanging', async function () {
+            // Accepts the connection, reads the body, never answers - what a
+            // black-holed flow looks like from the client side.
+            const server = http.createServer(function (req) {
+                req.resume();
+            });
+            const url = await listen(server);
+            const dispatcher = buildDispatcher({ agent: { headersTimeout: 300 } });
+            let code = null;
+            try {
+                await fetch(url, { method: 'POST', body: 'x', dispatcher });
+            } catch (e) {
+                code = e.cause ? e.cause.code : e.code;
+            } finally {
+                await closeDispatcher(dispatcher).catch(() => {});
+                shutdown(server);
+            }
+            assert.strictEqual(code, 'UND_ERR_HEADERS_TIMEOUT');
+        });
+
+        it('does not abort an upload that takes longer than the timeout', async function () {
+            // headersTimeout is armed once the request has been written, so a slow
+            // upload is not on its clock. If this ever regresses, sending a large
+            // photo or video over a slow uplink starts failing.
+            const server = http.createServer(function (req, res) {
+                req.resume();
+                req.on('end', function () {
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end('{"ok":true}');
+                });
+            });
+            const url = await listen(server);
+            const dispatcher = buildDispatcher({ agent: { headersTimeout: 300 } });
+            let chunks = 6;
+            const body = new Readable({
+                read() {
+                    const self = this;
+                    if (chunks > 0) {
+                        chunks--;
+                        setTimeout(function () {
+                            self.push(Buffer.alloc(1024, 0x41));
+                        }, 100);
+                    } else {
+                        self.push(null);
+                    }
+                },
+            });
+            let status = 0;
+            try {
+                const response = await fetch(url, { method: 'POST', body, duplex: 'half', dispatcher });
+                status = response.status;
+            } finally {
+                await closeDispatcher(dispatcher).catch(() => {});
+                shutdown(server);
+            }
+            assert.strictEqual(status, 200);
         });
     });
 

--- a/test/nodes/bot-node-restart.test.js
+++ b/test/nodes/bot-node-restart.test.js
@@ -385,6 +385,26 @@ describe('bot-node — undici dispatcher wiring on scheduleRestart (#442, V18.0.
         });
     });
 
+    it('buildDispatcherOptions arms a headers timeout that outlasts a long poll', function (t, done) {
+        // Without it undici waits out its 300 s default before reporting a socket
+        // black-holed by a WAN failover, and no recovery path runs in the meantime.
+        // The value must exceed pollTimeout (10 s) or every getUpdates long poll
+        // would time out instead of returning normally.
+        const flow = [{ id: 'b1', type: 'telegram bot', botname: 'b', updatemode: 'sendonly' }];
+        helper.load(telegrambotModule, flow, { b1: { token: 'fake' } }, function () {
+            try {
+                const n = helper.getNode('b1');
+                const opts = n.buildDispatcherOptions();
+                assert.strictEqual(typeof opts.agent.headersTimeout, 'number');
+                assert.ok(opts.agent.headersTimeout > n.pollTimeout * 1000);
+                assert.ok(opts.agent.headersTimeout < 300000);
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
     it('buildDispatcherOptions sets the family override when addressFamily is 4 or 6', function (t, done) {
         const flow = [{ id: 'b1', type: 'telegram bot', botname: 'b', updatemode: 'sendonly', addressfamily: 4 }];
         helper.load(telegrambotModule, flow, { b1: { token: 'fake' } }, function () {
@@ -429,6 +449,10 @@ describe('bot-node — undici dispatcher wiring on scheduleRestart (#442, V18.0.
                     password: 'p',
                 });
                 assert.strictEqual(typeof opts.socks.port, 'number');
+                // The agent options travel with the SOCKS path too — fetch-socks
+                // hands them to the Agent it builds, so a proxied bot gets the same
+                // headers deadline as a direct one.
+                assert.strictEqual(typeof opts.agent.headersTimeout, 'number');
                 done();
             } catch (err) {
                 done(err);

--- a/test/nodes/out-node.test.js
+++ b/test/nodes/out-node.test.js
@@ -1497,3 +1497,126 @@ describe('telegram sender (out-node) — callApi raw-API escape hatch', function
         });
     });
 });
+
+describe('telegram sender (out-node) — transient network failures are retried, not dropped', function () {
+    before(function (t, done) {
+        helper.startServer(done);
+    });
+
+    after(function (t, done) {
+        helper.stopServer(done);
+    });
+
+    afterEach(function () {
+        helper.unload();
+    });
+
+    function flow() {
+        return [
+            { id: 'b1', type: 'telegram bot', botname: 'b', updatemode: 'sendonly' },
+            { id: 's1', type: 'telegram sender', bot: 'b1', wires: [['out']] },
+            { id: 'out', type: 'helper' },
+        ];
+    }
+
+    // The shape node-telegram-bot-api hands us when the connection fails: the
+    // syscall code is in the cause chain, never in the top-level message.
+    function transportFailure(code, message) {
+        const leaf = new Error(message);
+        leaf.code = code;
+        const fatal = new Error('EFATAL: fetch failed');
+        fatal.code = 'EFATAL';
+        fatal.cause = new TypeError('fetch failed', { cause: leaf });
+        return fatal;
+    }
+
+    // Fails the first send with `error`, then succeeds — a connection that was
+    // down for one attempt, which is what a failover looks like to the sender.
+    function makeFlakyBotStub(record, error) {
+        const stub = { options: { baseApiUrl: 'https://api.telegram.org' } };
+        let calls = 0;
+        stub.sendMessage = function () {
+            calls++;
+            record.push(Array.from(arguments));
+            let result;
+            if (calls === 1) {
+                result = Promise.reject(error);
+            } else {
+                result = Promise.resolve({ message_id: 42 });
+            }
+            return result;
+        };
+        return stub;
+    }
+
+    function assertRetried(code, message, done) {
+        helper.load(telegrambotModule, flow(), { b1: { token: 'fake' } }, function () {
+            try {
+                const s = helper.getNode('s1');
+                const cfg = helper.getNode('b1');
+                const record = [];
+                const statuses = [];
+                const errors = [];
+                // One stub for the life of the test: getTelegramBot is called again
+                // on every retry, and a fresh stub would reset the failure counter.
+                const bot = makeFlakyBotStub(record, transportFailure(code, message));
+                cfg.getTelegramBot = function () {
+                    return bot;
+                };
+                s.error = function (e) {
+                    errors.push(e);
+                };
+                s.warn = function () {};
+                const status = s.status.bind(s);
+                s.status = function (o) {
+                    statuses.push(o);
+                    status(o);
+                };
+                // Retry sleeps retryDelayErrorNoConnection (10 s) before the second
+                // attempt; shorten it so the test does not wait that long.
+                s.retryDelayErrorNoConnection = 0.05;
+
+                s.receive({ payload: { chatId: 123, type: 'message', content: 'hello' } });
+
+                setTimeout(function () {
+                    try {
+                        // The failure was announced as a retry of the real code, and
+                        // the message was sent again rather than reported and dropped.
+                        const retryStatus = statuses.find(function (o) {
+                            return o.text && o.text.indexOf('retrying in') !== -1;
+                        });
+                        assert.ok(retryStatus, 'expected a "retrying in" status for ' + code);
+                        assert.ok(retryStatus.text.startsWith(code), 'expected status to name ' + code);
+                        assert.strictEqual(errors.length, 0);
+                        assert.strictEqual(record.length, 2);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                }, 400);
+            } catch (err) {
+                done(err);
+            }
+        });
+    }
+
+    it('retries a connection reset (pre-19.0.4 this was reported and dropped)', function (t, done) {
+        assertRetried('ECONNRESET', 'read ECONNRESET', done);
+    });
+
+    it('retries a socket closed under the request', function (t, done) {
+        assertRetried('UND_ERR_SOCKET', 'other side closed', done);
+    });
+
+    it('retries a request that ran out its headers timeout', function (t, done) {
+        assertRetried('UND_ERR_HEADERS_TIMEOUT', 'Headers Timeout Error', done);
+    });
+
+    it('retries an unreachable network', function (t, done) {
+        assertRetried('ENETUNREACH', 'connect ENETUNREACH 149.154.167.220:443', done);
+    });
+
+    it('retries a DNS failure', function (t, done) {
+        assertRetried('ENOTFOUND', 'getaddrinfo ENOTFOUND api.telegram.org', done);
+    });
+});


### PR DESCRIPTION

## The failure mode

When a router fails its WAN over, an ISP renews a dynamic IP, or a VPN route flips, every TCP
connection established through the old path is **black-holed**. Packets leave and go nowhere: no
RST, no FIN, no ICMP. From the process's point of view the socket is still open and the request it
is carrying is still in flight. Nothing arrives to say otherwise.

This is not an exotic condition — any dual-WAN or failover setup produces it on a schedule, and so
does a nightly PPPoE re-dial. Two things then go wrong here, in sequence.

### 1. The request hangs for five minutes, and no recovery path runs

`buildDispatcherOptions` builds the bot's undici dispatcher with `keepAliveTimeout: 4000` and no
`headersTimeout`, so it inherits undici's default of **300 s**. A request already on a black-holed
socket does not settle until that expires.

While it hangs, `telegramPolling._polling()` does not settle either, so it never reschedules, and it
emits neither `polling_error` nor `error`. `recordPollingError`, `scheduleRestart` and
`destroyDispatcher` — the recovery machinery built for #440 / #442 — are therefore never reached.
The bot sits on a green "polling" status while senders queue behind the same dead pooled socket.
Nothing in the node's own defences can fire, because all of them are downstream of an error that is
never emitted.

### 2. When it finally does fail, the message is dropped

`processError` classifies a failure by searching the stringified exception:

```js
const errorNotFound = String(exception).includes('ENOTFOUND');
const errorConnectionReset = String(exception).includes('ECONNRESET');
```

Since V18.0.0 moved the transport to `fetch`, that string is never either of those.
node-telegram-bot-api reports every transport failure as `FatalError: EFATAL: fetch failed`, Node's
fetch wraps the real failure as `TypeError: fetch failed`, and the code that says what actually
happened sits two levels down in `.cause`:

```
FatalError  EFATAL: fetch failed          code = EFATAL
  └ TypeError  fetch failed               code = undefined
      └ Error  read ECONNRESET            code = ECONNRESET
```

Confirmed against master, by sending through the real library to a server that resets the
connection:

```
String(e)                         -> "FatalError: EFATAL: fetch failed"
String(e).includes('ECONNRESET')  -> false
e.cause.cause.code                -> "ECONNRESET"
```

So **both checks have been dead since 18.0.0**, and every connection failure takes the non-retry
path: `node.error`, and the message is gone. A reset connection — the one case the code explicitly
set out to retry — is currently reported and dropped. (The 429 / flood-wait branch is unaffected:
`ETELEGRAM` errors do carry their text at the top level, so that check still matches.)

The two faults compound. Without a timeout the failure is invisible; add a timeout and the failure
becomes a dropped message. Either way the message the user asked to send is not sent — and messages
about connectivity are exactly the ones being sent when connectivity changes.

## Field evidence

From a Node-RED install that sends router and monitoring alerts to Telegram, on a link that fails
over roughly once a day.

Before any patching, a failover would leave the bot showing a green "polling" status with every
send hanging, for about 15 minutes, until a manual redeploy. That matches the black-holed-socket
path above (on that host the wait ended at the kernel's `tcp_retries2` rather than at undici's
300 s — see the note below).

With a request deadline in place but the retry list unchanged, the hang became a drop. During the
failover on 2026-09-10 the two messages emitted in the same second as the route change were lost —
`Fibra is down` at 18:55:19 and `Fibra is up` at 18:55:39 — while the next messages, sent 15 s and
81 s later, arrived normally. Nothing was logged beyond the sender's own `node.error`; the messages
were simply never delivered. Adding the transient codes to the retry list fixed it: subsequent
failovers log `retrying in 10s` and the message arrives on the next attempt.

**Provenance, stated plainly:** that deployment runs **17.4.17**, where the transport is still
`@cypress/request` — there the timeout is `request.timeout` and the error is `ESOCKETTIMEDOUT`. The
*failure mode* carries over to master unchanged, but the mechanism and the error codes do not, so
this PR is not a port of those patches. Everything asserted about master above was re-derived
against `19.0.2` with undici 7.29.0 / Node 22+, and is covered by the tests below.

## The changes

Two commits; the first is a prerequisite for the second.

**1. `fix(bot-node): bound the wait for Bot API response headers`**

Builds the dispatcher with `headersTimeout: 20000`, so a black-holed socket fails in 20 s instead of
300 s and the existing recovery paths actually get an error to act on.

`headersTimeout` — not a total request timeout — is the right instrument here: undici arms it once
the request body has been written, so it is **not** a cap on upload duration. A slow upload of a
large photo or video is unaffected; there is a regression test that sends a body slower than the
timeout and asserts the request still completes. 20 s clears `pollTimeout` (10 s) with room to
spare, since `getUpdates` long-polls for that long before Telegram writes response headers.
`connectTimeout` and `bodyTimeout` keep undici's defaults. The value rides on the agent options, so
SOCKS-proxied bots get it too.

**2. `fix(out-node): retry transient network failures instead of dropping the message`**

Moves classification into `lib/transient-errors.js` (`findTransientErrorCode`), which walks the
`.cause` chain — and `AggregateError.errors`, the shape a dual-stack host produces when both its A
and AAAA addresses fail — and covers the whole family rather than two members of it:

`ECONNRESET`, `ECONNREFUSED`, `ECONNABORTED`, `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `EHOSTDOWN`,
`EHOSTUNREACH`, `ENETDOWN`, `ENETRESET`, `ENETUNREACH`, `EPIPE`, plus undici's `UND_ERR_SOCKET`,
`UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT` and `UND_ERR_BODY_TIMEOUT`. These are all the
same fault — the request never reached Telegram, or its answer never came back — and all deserve
the `retryDelayErrorNoConnection` treatment that `ECONNRESET` was already meant to get.

Deliberately **not** retried:

- `UND_ERR_CLOSED` / `UND_ERR_DESTROYED` — the dispatcher was closed by us (node close, redeploy,
  `scheduleRestart`); a retry there fights the shutdown that caused it.
- `ETELEGRAM` — Telegram received the request and rejected it on its merits. A bad chat id or a
  malformed Markdown entity still surfaces immediately instead of looping, preserving #450 / #455
  behaviour.

The status text now names the code that was found (`ECONNRESET: retrying in 10s`) rather than the
`EFATAL` wrapper it arrived in.

## Scope and risk

- No configuration change, no new option, no dependency change. Two behavioural changes: requests
  give up after 20 s of silence instead of 300 s, and failures that were dropped are now retried
  every 10 s via the existing `repeatProcessMessage` path.
- The retry uses the queue machinery already in place; a chat's queue still advances on
  non-retryable errors, so the #450 / #455 wedge fixes are untouched.
- Sends that are genuinely never going to succeed will now retry rather than error out once. That
  is the existing `ECONNRESET` contract applied consistently — worth confirming you are happy with
  it as the default, since a permanently offline host will now retry indefinitely rather than
  reporting per message.
- `CHANGELOG.md` and the `package.json` patch version are updated per `AGENTS.md`, one bump per
  commit (19.0.3 and 19.0.4) — happy to squash to a single version if you'd rather.
- `doc/architecture/structural-design.md` and `behavioural-design.md` described the old
  429/`ENOTFOUND`/`ECONNRESET` classification and are updated. ADR 0003 mentions it too but reads as
  a historical record, so I left it alone. Glad to add an ADR for this if you want one.

## Testing

`npm run lint`, `npm run format:check`, `npm test` and `npm run coverage:check` all pass — 322
tests, 14 new. The suite still exits on its own (no `--test-force-exit`).

New coverage:

- `test/lib/transient-errors.test.js` — the chain walk, the AggregateError shape, the excluded
  codes, and an end-to-end case that throws a **real** error out of node-telegram-bot-api against a
  server that resets the connection, asserting both that `String(error)` does *not* contain the code
  and that the walk finds it. If the library ever changes how it wraps transport failures, that test
  fails rather than the behaviour silently regressing again.
- `test/lib/undici-pool.test.js` — a black-holed request rejects with `UND_ERR_HEADERS_TIMEOUT`
  instead of hanging, and an upload slower than the timeout still completes.
- `test/nodes/bot-node-restart.test.js` — the dispatcher options carry a headers timeout above
  `pollTimeout`, on both the direct and the SOCKS paths.
- `test/nodes/out-node.test.js` — five wrapped transport failures (`ECONNRESET`, `UND_ERR_SOCKET`,
  `UND_ERR_HEADERS_TIMEOUT`, `ENETUNREACH`, `ENOTFOUND`) are retried and the message is sent on the
  second attempt, with no `node.error`.

All five out-node tests fail against master and pass with the change, which is the regression the
PR is about.

## Related

#442 (connection breaks after weeks; the report quotes `read ETIMEDOUT`, one of the codes this now
retries) and #455 / #450 for the queue-advance behaviour this preserves. Both are closed; this is a
different mechanism, not a reopening of either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfjX5R6B2BjtXBRNLzXeHN
